### PR TITLE
Flattened out start command

### DIFF
--- a/.devcontainer/post.sh
+++ b/.devcontainer/post.sh
@@ -30,7 +30,9 @@ if [[ ("${1,,}" == "bundle") || ("${1,,}" == "start") ]]; then
 fi
 
 if [[ "${1,,}" == "start" ]]; then
-    cd $PARENT/docs && bundle update && nohup bundle exec jekyll serve  --force_polling --livereload > $PARENT/jekyll.out 2>&1 &
+    cd $PARENT/docs
+    bundle update 
+    nohup bundle exec jekyll serve  --force_polling --livereload > $PARENT/jekyll.out 2>&1 &
     sleep 4
     tail $PARENT/jekyll.out
     echo "Jekyll started, to monitor see $PARENT/jekyll.out"

--- a/.devcontainer/post.sh
+++ b/.devcontainer/post.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -xe
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 PARENT="$(dirname "$SCRIPT_DIR")"
@@ -31,7 +33,7 @@ fi
 
 if [[ "${1,,}" == "start" ]]; then
     cd $PARENT/docs
-    bundle update 
+    bundle update
     nohup bundle exec jekyll serve  --force_polling --livereload > $PARENT/jekyll.out 2>&1 &
     sleep 4
     tail $PARENT/jekyll.out


### PR DESCRIPTION
For some reason, this change was necessary to get the start command to work. I'm guessing my environment is different than Christopher's in some subtle way. It looks to me like what's there is valid, and I can't really explain it.