### PR TITLE
Moved the "REST as an OT person" article to new articles section

### DIFF
--- a/docs/_posts/2024-01-27-trolie-intro-for-ems-background.md
+++ b/docs/_posts/2024-01-27-trolie-intro-for-ems-background.md
@@ -1,22 +1,21 @@
 ---
-title: TROLIE, REST and OpenAPI for the EMS 
+title: TROLIE, REST and OpenAPI for EMS and OT Experts
 layout: post
 author: Tory McKeag, Principal Software Architect, GE Vernova
 ---
 
+# FERC 881 and EMS
+Thermal line limits are critical to many decisions made on the transmission grid.  Therefore, unsurprisingly, the need to exchange AARs affects many software systems used by utilities and other grid operators.  However, by far the most common among these are Energy Management Systems (EMS) that provide real-time monitoring and control of the transmission grid to control centers.  These systems are implemented by a diverse landscape of vendors, and are used by the vast majority of entities with operations responsibility for the transmission grid, including utilities, transmission companies, transmission owners, reliability coordinators, ISO/RTOs, and of course organizations with combinations of these roles.  There will need to be many EMS integrations with TROLIE.  
+
+EMS systems have been around a long time, with their origins of current functional design dating to the mid-1970s.  Depending on the vendor, EMS technology may be fairly old, some of which significantly pre-dates REST.  Many EMS platforms have traditionally used older methods for data exchanges, such as SCADA protocols, custom TCP-based protocols, and ad-hoc file exchanges.  Representational State Transfer (REST), the technology used for TROLIE, _may_ be unfamiliar to engineers who regularly work on the EMS in what is often referred to as an operations technology (OT) environment.  This article aims to provide a brief introduction to REST from the perspective of an EMS/OT expert in the hopes of making TROLIE more accessible.  
+
 # Why REST and OpenAPI?
 
-While REST isn’t new. It was first published in [academic literature in the
+While REST may be new (or rarely used) in some EMS systems, it certainly isn't new. It was first published in [academic literature in the
 year 2000](https://ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm).
 
-However, it may imply a learning curve for typical operations technology (OT)
-teams that need to integrate with TROLIE. This is because EMS systems are the
-most common integration targets for TROLIE, where older methods have frequently
-been used for data exchanges, such as SCADA protocols, custom TCP-based
-protocols, and ad-hoc file exchanges.
-
-TROLIE is built on the philosophy that this is an acceptable tradeoff due to the
-upside that REST offers over these traditional data exchange methods. An entire
+TROLIE is built on the philosophy that the adoption of REST vs traditional EMS-centric/OT exchange methods is an acceptable tradeoff due to the
+upside that REST offers over these traditional methods. An entire
 paper could be written purely on this subject as to the benefits of using REST
 for this sort of complex data exchange. To summarize:
 

--- a/docs/_posts/2024-01-27-trolie-intro-for-ems-background.md
+++ b/docs/_posts/2024-01-27-trolie-intro-for-ems-background.md
@@ -1,6 +1,7 @@
 ---
-title: Why REST and OpenAPI?
-nav_order: 2
+title: TROLIE, REST and OpenAPI for the EMS 
+layout: post
+author: Tory McKeag, Principal Software Architect, GE Vernova
 ---
 
 # Why REST and OpenAPI?

--- a/docs/articles.md
+++ b/docs/articles.md
@@ -1,0 +1,9 @@
+---
+title: Articles
+nav_order: 6
+has_children: true
+---
+
+# TROLIE Articles
+
+A series of informal articles on the design and usage of TROLIE.

--- a/docs/articles/trolie-for-ems-and-ot.md
+++ b/docs/articles/trolie-for-ems-and-ot.md
@@ -1,15 +1,17 @@
 ---
 title: TROLIE, REST and OpenAPI for EMS and OT Experts
-layout: post
-author: Tory McKeag, Principal Software Architect, GE Vernova
+parent: Articles
 ---
 
-# FERC 881 and EMS
+# {{ page.title }}
+
+
+## FERC 881 and EMS
 Thermal line limits are critical to many decisions made on the transmission grid.  Therefore, unsurprisingly, the need to exchange AARs affects many software systems used by utilities and other grid operators.  However, by far the most common among these are Energy Management Systems (EMS) that provide real-time monitoring and control of the transmission grid to control centers.  These systems are implemented by a diverse landscape of vendors, and are used by the vast majority of entities with operations responsibility for the transmission grid, including utilities, transmission companies, transmission owners, reliability coordinators, ISO/RTOs, and of course organizations with combinations of these roles.  There will need to be many EMS integrations with TROLIE.  
 
 EMS systems have been around a long time, with their origins of current functional design dating to the mid-1970s.  Depending on the vendor, EMS technology may be fairly old, some of which significantly pre-dates REST.  Many EMS platforms have traditionally used older methods for data exchanges, such as SCADA protocols, custom TCP-based protocols, and ad-hoc file exchanges.  Representational State Transfer (REST), the technology used for TROLIE, _may_ be unfamiliar to engineers who regularly work on the EMS in what is often referred to as an operations technology (OT) environment.  This article aims to provide a brief introduction to REST from the perspective of an EMS/OT expert in the hopes of making TROLIE more accessible.  
 
-# Why REST and OpenAPI?
+## Why REST and OpenAPI?
 
 While REST may be new (or rarely used) in some EMS systems, it certainly isn't new. It was first published in [academic literature in the
 year 2000](https://ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm).
@@ -47,7 +49,7 @@ architecture in detail, users of the TROLIE APIs do not need to be experts in
 REST. From a user perspective, REST could be seen as a minor cognitive leap
 from file exchanges, which this document will illustrate through examples.
 
-## Why not ICCP?
+### Why not ICCP?
 The Inter-Control Center Communications Protocol (ICCP), part of IEC standard
 60870-6, is used frequently to integrate Reliability Coordinators' SCADA system
 with member transmission owners' SCADA systems to capture all kinds of telemetry
@@ -75,7 +77,7 @@ forecasted data. There are a couple reasons for this:
 
 This is all in addition to considering the advantages of REST discussed above.
 
-## Why not File Exchanges?
+### Why not File Exchanges?
 
 Unlike ICCP, file exchanges using common formats such as CSV, XML, and JSON do
 allow for more complex data structures. The advantages to REST however over

--- a/docs/articles/trolie-for-ems-and-ot.md
+++ b/docs/articles/trolie-for-ems-and-ot.md
@@ -4,7 +4,7 @@ parent: Articles
 ---
 
 # {{ page.title }}
-
+_January 27, 2024_
 
 ## FERC 881 and EMS
 Thermal line limits are critical to many decisions made on the transmission grid.  Therefore, unsurprisingly, the need to exchange AARs affects many software systems used by utilities and other grid operators.  However, by far the most common among these are Energy Management Systems (EMS) that provide real-time monitoring and control of the transmission grid to control centers.  These systems are implemented by a diverse landscape of vendors, and are used by the vast majority of entities with operations responsibility for the transmission grid, including utilities, transmission companies, transmission owners, reliability coordinators, ISO/RTOs, and of course organizations with combinations of these roles.  There will need to be many EMS integrations with TROLIE.  

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,6 +1,6 @@
 ---
 title: TROLIE Concepts
-nav_order: 3
+nav_order: 2
 ---
 
 # TROLIE Concepts

--- a/docs/daylight-savings.md
+++ b/docs/daylight-savings.md
@@ -1,6 +1,6 @@
 ---
 title: Daylight Savings
-nav_order: 5
+nav_order: 4
 ---
 
 # Handling Daylight Savings Transitions in TROLIE

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -1,6 +1,6 @@
 ---
 title: Usage Examples
-nav_order: 4
+nav_order: 3
 has_children: true
 ---
 


### PR DESCRIPTION
I tried a few things with this, and this is what I settled on.  I tried the blog functions in Jekyll, and they don't work very well with the just the docs theme- there's no built-in navigation, and even if I hand-code a page to list and navigate, they don't get added to the search index.  

From a reader perspective however, I tried formatting this article like a blog, with an author and date.  I feel like the date is OK, because it is likely helpful to the reader to know the thing is dated (and starting to age as we speak).  However, I put the author in there and it felt quite self-serving as I looked at the end result, and it felt questionably appropriate for the spirit of the project.  

I also added some intro to the article that I'm hoping clarifies the audience.  

Oh yes, and I changed around the nav orders- there is an open slot (5) for ADRs, which I will do in a separate PR.  