### PR TITLE
Minor cleanup items

### DIFF
--- a/docs/_data/components/schemas/generic-identifier.yaml
+++ b/docs/_data/components/schemas/generic-identifier.yaml
@@ -1,10 +1,7 @@
 type: string
 description: |
 
-  Contains a unique identifier for an object. Where practicable, using a URI is
-  generally recommended. However there is no functionality defined by TROLIE
-  that is contingent upon the properties or structure of a `generic-identifier`;
-  they are effectively opaque in the exchange.
+  Contains a unique identifier for an object. 
 
 maxLength: 100
 pattern: ^(.){0,500}$

--- a/docs/_data/components/schemas/names.yaml
+++ b/docs/_data/components/schemas/names.yaml
@@ -17,6 +17,5 @@ properties:
           $ref: ./generic-identifier.yaml
       required:
         - name
-        - authority
 required:
   - resource-id


### PR DESCRIPTION
Contributes to #82 
Closes #4 

My #4 issue is pretty old, and this is about the only thing I saw as I dug through forecasts- it is possible to have a name type without an authority, and in many cases it can be too much.  Otherwise, I think we look good.  

I also removed the recommendation for URIs in the IDs.  I don't think it's appropriate here.  First of all, I'm not sure I agree with it, but even before we get there I think we've crossing our opinions into modeling, which we've agreed is a slippery slope into a larger project.  