### PR TITLE
add Forecasting tag

### DIFF
--- a/docs/_data/openapi-split.yaml
+++ b/docs/_data/openapi-split.yaml
@@ -54,6 +54,9 @@ servers:
   - url: https://trolie.example.com
 tags:
 
+  - name: Forecasting
+    description: The operations related to forecasting.
+
   - name: Operating Snapshots
     description: >
       Two snapshots are provided:

--- a/docs/_data/paths/limits_forecast-snapshot.yaml
+++ b/docs/_data/paths/limits_forecast-snapshot.yaml
@@ -3,6 +3,7 @@ get:
   summary: Limits Forecast Snapshot
   tags:
     - Operating Snapshots
+    - Forecasting
   parameters:
     - $ref: ../components/parameters/offset-period-start.yaml
     - $ref: ../components/parameters/period-end.yaml

--- a/docs/_data/paths/rating-proposals_forecasts.yaml
+++ b/docs/_data/paths/rating-proposals_forecasts.yaml
@@ -24,6 +24,7 @@ get: &get
 
   tags:
     - Rating Proposals
+    - Forecasting
   responses:
     '200':
       description: OK


### PR DESCRIPTION
I think this will be helpful in announcing since we can share the link trolie.energy/spec#tag/Forecasting and it will render expanded.

![image](https://github.com/trolie/spec/assets/70229/15d864a3-ad75-426d-accd-62993b6ff98e)
