### PR TITLE
Tags cleanup

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,5 +1,7 @@
 source ENV['GEM_REPO']
 
+gem "faraday", '>= 2.9', '< 2.10'
+
 gem "github-pages", "~> 228", group: :jekyll_plugins
 
 gem "webrick", "~> 1.8"

--- a/docs/_data/openapi-split.yaml
+++ b/docs/_data/openapi-split.yaml
@@ -80,40 +80,7 @@ tags:
 
       These ratings may be either AARs or DLRs.  
 
-  - name: Operating Snapshots
-    description: >
-      Two snapshots are provided:
-
-      * **Operating Limits Forecast Snapshot** is the forecast of Transmission
-        Facility ratings that is in-use by the Transmission Provider at the time
-        of the request for this resource.  These are actively used for look-ahead operational decisions, such as the
-        day-ahead market, in addition to their role as recourse limits if real-time ratings
-        proposals are missing.  
-      * **Operating Limits Real-Time Snapshot** is the set of System Operating
-      Limits the
-        Transmission Provider is operating to at the time of the request for
-        this resource.  
-  - name: Rating Proposals
-    description: >
-
-      Ratings Providers may submit ratings for three separate time horizons:
-
-      * **Forecast Ratings** are at minimum hourly forecasts of ratings for a
-      particular segment.  
-
-      * **Real-Time Ratings** are provided for current operating conditions. 
-      Ratings provided in this manner are an alternative for segments where ICCP
-      communications are not available.  
-
-      * **Seasonal Ratings** are recourse ratings for when applicable forecast
-      ratings are not available.  In addition to use when forecast rating feeds
-      are missing, these may be used by planning or other forward-looking
-      processes that go beyond the window for which forecasted ratings may be
-      available.  This includes ratings for scheduled calendar seasons, as well
-      as to rating sets that apply in special named scenarios defined by the
-      Transmission Provider, such as an extreme winter day.  
-
-  - name: Seasonal Rating Snapshots
+  - name: Seasonal
     description: >
       While not typically used directly in operational decisions, seasonal
       ratings are provided for two purposes:
@@ -190,14 +157,20 @@ paths:
     $ref: paths/limits_forecast-snapshot.yaml
   /limits/realtime-snapshot:
     $ref: paths/limits_realtime-snapshot.yaml
+  /rating-proposals/forecast:
+    $ref: paths/rating-proposals_forecasts.yaml
+  /rating-proposals/realtime:
+    $ref: paths/rating-proposals_realtime.yaml
+  /rating-proposals/seasonal:
+    $ref: paths/rating-proposals_seasonal.yaml
+  /rating-proposals/seasonal/{ratings-provider}:
+    $ref: paths/rating-proposals_seasonal_{ratings-provider}.yaml
   /seasonal-ratings/snapshot:
     $ref: paths/seasonal-ratings_snapshot.yaml
   /seasonal-ratings/season-instances:
     $ref: paths/seasonal-ratings_season-instances.yaml
   /seasonal-ratings/season-instances/{id}:
     $ref: paths/seasonal-ratings_season-instances_{id}.yaml
-  /rating-proposals/forecast:
-    $ref: paths/rating-proposals_forecasts.yaml
   /temporary-aar-exceptions:
     $ref: paths/temporary-aar-exceptions.yaml
   /temporary-aar-exceptions/{id}:
@@ -206,12 +179,6 @@ paths:
     $ref: paths/temporary-seasonal-ratings.yaml
   /temporary-seasonal-ratings/{id}:
     $ref: paths/temporary-seasonal-ratings_{id}.yaml
-  /rating-proposals/realtime:
-    $ref: paths/rating-proposals_realtime.yaml
-  /rating-proposals/seasonal:
-    $ref: paths/rating-proposals_seasonal.yaml
-  /rating-proposals/seasonal/{ratings-provider}:
-    $ref: paths/rating-proposals_seasonal_{ratings-provider}.yaml
 components:
   responses:
 

--- a/docs/_data/paths/limits_forecast-snapshot.yaml
+++ b/docs/_data/paths/limits_forecast-snapshot.yaml
@@ -2,7 +2,6 @@ get:
   operationId: getLimitsForecastSnapshot
   summary: Limits Forecast Snapshot
   tags:
-    - Operating Snapshots
     - Forecasting
   parameters:
     - $ref: ../components/parameters/offset-period-start.yaml

--- a/docs/_data/paths/limits_realtime-snapshot.yaml
+++ b/docs/_data/paths/limits_realtime-snapshot.yaml
@@ -11,7 +11,6 @@ get:
 
   summary: Limits Real Time Snapshot
   tags:
-    - Operating Snapshots
     - Real-Time
   parameters:
     - $ref: ../components/parameters/monitoring-set-filter.yaml

--- a/docs/_data/paths/rating-proposals_forecasts.yaml
+++ b/docs/_data/paths/rating-proposals_forecasts.yaml
@@ -1,6 +1,6 @@
 get: &get
   operationId: getRatingForecastProposalStatus
-  summary: Obtain the status of the Ratings Provider's forecast proposal
+  summary: Obtain forecast proposal status
   description: |
 
     Used to obtain the status of the Ratings Forecast proposal. The response is
@@ -23,7 +23,6 @@ get: &get
     independent clients used by the same provider count against the same quota.
 
   tags:
-    - Rating Proposals
     - Forecasting
   responses:
     '200':

--- a/docs/_data/paths/rating-proposals_realtime.yaml
+++ b/docs/_data/paths/rating-proposals_realtime.yaml
@@ -1,4 +1,4 @@
-get: &get
+get:
   operationId: getRealTimeProposalStatus
   summary: Obtain the status of the Ratings Provider's Real-Time proposals
   description: |
@@ -22,14 +22,13 @@ get: &get
     limiting is done on a per Ratings Provider basis, so requests from
     independent clients used by the same provider count against the same quota.
 
-  tags:
-    - Rating Proposals
+  tags: &tags
     - Real-Time
   responses:
     '200':
       description: OK
       content:
-        application/vnd.trolie.rating-realtime-proposal-status.v1+json: &status-response
+        application/vnd.trolie.rating-realtime-proposal-status.v1+json:
           schema:
             $ref: ../components/schemas/array-max-monitored-elements.yaml#/real-time-proposal-status
           example:
@@ -83,9 +82,7 @@ post:
     data that is either completely missing, or is considered stale by the Clearinghouse Provider,
     likely due to simply not receiving a value within a reasonable period, such as an hour.  
 
-  tags:
-    - Rating Proposals
-    - Real-Time
+  tags: *tags
 
   requestBody:
     content:
@@ -111,14 +108,10 @@ post:
       headers:
         $ref: '../openapi-split.yaml#/components/responses/204/headers'
 
-    '400':
-      $ref: '../openapi-split.yaml#/components/responses/400-problem'
-    '401':
-      $ref: '../openapi-split.yaml#/components/responses/401-empty'
-    '403':
-      $ref: '../openapi-split.yaml#/components/responses/403-empty'
-    '406':
-      $ref: '../openapi-split.yaml#/components/responses/406-empty'
+    '400': *malformed
+    '401': *unauthorized-empty
+    '403': *forbidden-empty
+    '406': *not-acceptable-empty
     '413':
       $ref: '../openapi-split.yaml#/components/responses/413-empty'
     '422':
@@ -147,10 +140,8 @@ post:
             $ref: '../../articles/examples/incomplete-proposal.json'
       headers:
         $ref: '../openapi-split.yaml#/components/responses/304/headers'
-    '429':
-      $ref: '../openapi-split.yaml#/components/responses/429-empty'
-    '500': &unexpected-error-empty
-      $ref: '../openapi-split.yaml#/components/responses/500-empty'
+    '429': *rate-limit-hit
+    '500': *unexpected-error-empty
     default: *unexpected-error-empty
   security:
     - oauth2-primary-flow:

--- a/docs/_data/paths/rating-proposals_seasonal.yaml
+++ b/docs/_data/paths/rating-proposals_seasonal.yaml
@@ -9,7 +9,7 @@ get:
 
   summary: Get a Seasonal Rating Proposal
   tags: &tags
-    - Rating Proposals
+    - Seasonal
   parameters:
     - $ref: ../components/parameters/monitoring-set-filter.yaml
     - $ref: ../components/parameters/segment-filter.yaml

--- a/docs/_data/paths/rating-proposals_seasonal_{ratings-provider}.yaml
+++ b/docs/_data/paths/rating-proposals_seasonal_{ratings-provider}.yaml
@@ -2,8 +2,8 @@ get:
   operationId: getSeasonalProposalForProvider
   description: &get_desc Obtain a specific rating proposal by ratings provider
   summary: *get_desc
-  tags:
-    - Rating Proposals
+  tags: &tags
+    - Seasonal
   parameters:
     - $ref: ../components/parameters/ratings-provider.yaml
     - $ref: ../components/parameters/monitoring-set-filter.yaml
@@ -49,8 +49,7 @@ patch:
   operationId: patchSeasonalProposalByProvider
   description: &patch_desc Update a given Provider's Rating Proposal 
   summary: *patch_desc
-  tags:
-    - Rating Proposals
+  tags: *tags
   parameters:
     - $ref: ../components/parameters/ratings-provider.yaml
   requestBody:

--- a/docs/_data/paths/seasonal-ratings_season-instances.yaml
+++ b/docs/_data/paths/seasonal-ratings_season-instances.yaml
@@ -3,7 +3,7 @@ get:
   description: Seasonal ratings are always bound against season instances, with effective dates.
   summary: Get Instances of Seasons
   tags:
-    - Seasonal Rating Snapshots
+    - Seasonal
   responses:
     '200':
       description: OK

--- a/docs/_data/paths/seasonal-ratings_season-instances_{id}.yaml
+++ b/docs/_data/paths/seasonal-ratings_season-instances_{id}.yaml
@@ -3,7 +3,7 @@ get:
   description: &get_desc Gets a single season instance.
   summary: *get_desc
   tags:
-    - Seasonal Rating Snapshots
+    - Seasonal
   parameters:
     - $ref: ../components/parameters/id.yaml
   responses:

--- a/docs/_data/paths/seasonal-ratings_snapshot.yaml
+++ b/docs/_data/paths/seasonal-ratings_snapshot.yaml
@@ -3,7 +3,7 @@ get:
   description: Retrieve the nominal and seasonal ratings.
   summary: Get Seasonal Ratings
   tags:
-    - Seasonal Rating Snapshots
+    - Seasonal
   parameters:
     - $ref: ../components/parameters/monitoring-set-filter.yaml
     - $ref: ../components/parameters/facility-filter.yaml

--- a/docs/_data/paths/temporary-aar-exceptions_{id}.yaml
+++ b/docs/_data/paths/temporary-aar-exceptions_{id}.yaml
@@ -2,7 +2,7 @@ get:
   operationId: getTemporaryAARException
   description: &get_desc Obtain a specific temporary AAR exception by Id.
   summary: *get_desc
-  tags:
+  tags: &tags
     - Temporary AAR Exceptions
   parameters:
     - $ref: ../components/parameters/id.yaml
@@ -65,8 +65,7 @@ delete:
   operationId: deleteTemporaryAARException
   description: &delete_desc Delete a specific temporary AAR Exception by Id.  
   summary: *delete_desc
-  tags:
-    - Temporary AAR Exceptions
+  tags: *tags
   parameters:
     - $ref: ../components/parameters/id.yaml
   responses:
@@ -90,8 +89,7 @@ put:
   operationId: updateTemporaryAARException
   description: &put_desc Updates an existing Temporary AAR Exception.  
   summary: *put_desc
-  tags:
-    - Temporary AAR Exceptions
+  tags: *tags
   parameters:
     - $ref: ../components/parameters/id.yaml
   requestBody:

--- a/docs/_data/paths/temporary-seasonal-ratings_{id}.yaml
+++ b/docs/_data/paths/temporary-seasonal-ratings_{id}.yaml
@@ -2,7 +2,7 @@ get:
   operationId: getTemporarySeasonalRating
   description: &get_desc Obtain a specific temporary seasonal rating by Id.  
   summary: *get_desc
-  tags:
+  tags: &tags
     - Temporary Seasonal Ratings
   parameters:
     - $ref: ../components/parameters/id.yaml
@@ -62,8 +62,7 @@ delete:
   operationId: deleteTemporarySeasonalRating
   description: &delete_desc Delete a specific temporary seasonal rating by its Id.
   summary: *delete_desc
-  tags:
-    - Temporary Seasonal Ratings
+  tags: *tags
   parameters:
     - $ref: ../components/parameters/id.yaml
   responses:
@@ -87,8 +86,7 @@ put:
   operationId: updateTemporarySeasonalRating
   description: &put_desc Updates an existing Temporary Seasonal Rating.  
   summary: *put_desc
-  tags:
-    - Temporary Seasonal Ratings
+  tags: *tags
   parameters:
     - $ref: ../components/parameters/id.yaml
   requestBody:


### PR DESCRIPTION
this is just a maintenance change, reorganizing the Redocly rendered navigation a bit to deprecate the "Operating Snapshots" and "Ratings Proposals" tags. I also had to pin a bundler dependency that was breaking the jekyll render locally.

![image](https://github.com/user-attachments/assets/d57227c6-c211-4606-9716-e3e7e8105166)
 