### PR TITLE
fix limit types

### DIFF
--- a/docs/_data/components/schemas/limit-types/active-power-with-power-factor.yaml
+++ b/docs/_data/components/schemas/limit-types/active-power-with-power-factor.yaml
@@ -1,5 +1,5 @@
 type: object
-title: Active Power
+title: Active Power and Power Factor
 additionalProperties: false
 properties:
   mw:
@@ -8,5 +8,12 @@ properties:
     format: float
     minimum: 1
     maximum: 10000
+  pf:
+    type: number
+    description: Assumed power factor.
+    format: float
+    minimum: 0
+    maximum: 1
 required:
   - mw
+  - pf

--- a/docs/_data/components/schemas/limit-types/apparent-power.yaml
+++ b/docs/_data/components/schemas/limit-types/apparent-power.yaml
@@ -1,4 +1,5 @@
 type: object
+title: Apparent Power
 additionalProperties: false
 properties:
   mva:

--- a/docs/_data/components/schemas/limit-types/current.yaml
+++ b/docs/_data/components/schemas/limit-types/current.yaml
@@ -1,11 +1,12 @@
 type: object
+title: Current (nominal voltage assumed)
+description: >-
+  Representation of a limit in amperes. Assumes that Clearinghouse Provider
+  has the nominal voltage in its model.
 additionalProperties: false
 properties:
   amps:
     type: number
-    description: >-
-      Representation of a limit in amperes. Assumes that Clearinghouse Provider
-      has the nominal voltage in its model.
     format: float
     minimum: 1
     maximum: 100000

--- a/docs/_data/components/schemas/limit-types/reactive-power.yaml
+++ b/docs/_data/components/schemas/limit-types/reactive-power.yaml
@@ -1,9 +1,10 @@
 type: object
+title: Reactive Power
+description: Representation of a limit in megavolt-amperes reactive (MVAR).
 additionalProperties: false
 properties:
   mvar:
     type: number
-    description: Representation of a limit in megavolt-amperes reactive (MVAR).
     format: float
     minimum: -10000
     maximum:  10000

--- a/docs/_data/components/schemas/limit-types/voltage.yaml
+++ b/docs/_data/components/schemas/limit-types/voltage.yaml
@@ -1,52 +1,71 @@
 overvoltage-threshold-pu:
   type: object
+  title: Overvoltage Threshold per unit (nominal voltage assumed)
+  description: >
+    An upper limit to voltage for a transmission facility in per unit with
+    the base voltage assumed to be the nominal voltage.
   additionalProperties: false
   properties:
     voltage-pu-max: &pu
       type: number
-      description: >
-        An upper limit to voltage for a transmission facility in per unit.
       format: float
       minimum: 0
       maximum: 2
-    base-kV: &voltage
-      type: number
-      description: >
-        The base voltage in kilovolts for the per unit voltage.
-      format: int32
-      minimum: 0
-      maximum: 1100
   required:
   - voltage-pu-max
 
 overvoltage-threshold:
   type: object
+  title: Overvoltage Threshold
+  description: An upper limit to voltage for a transmission facility in kilovolts.
   additionalProperties: false
   properties:
-    kV-max: 
-      <<: *voltage
-      description: >
-        An upper limit to voltage for a transmission facility in kilovolts.
+    kV-max: &voltage
+      type: number
+      format: int32
+      minimum: 0
+      maximum: 1100
   required:
     - kV-max
 
 undervoltage-threshold-pu:
   type: object
+  title: Undervoltage Threshold per unit (nominal voltage assumed)
+  description: >
+    An lower limit to voltage for a transmission facility in per unit
+    with the nominal voltage assumed to be the base voltage.
   additionalProperties: false
   properties:
     voltage-pu-min:
       <<: *pu
-      description: An lower limit to voltage for a transmission facility in per unit.
-    base-kV: *voltage
   required:
   - voltage-pu-min
 
 undervoltage-threshold:
   type: object
+  title: Undervoltage Threshold
+  description: A lower limit to voltage for a transmission facility in kilovolts.
   additionalProperties: false
   properties:
     kV-min:
       <<: *voltage
-      description: A lower limit to voltage for a transmission facility in kilovolts.
   required:
     - kV-min
+
+current-with-kV:
+  type: object
+  title: Current
+  description: Representation of a limit in amperes and associated voltage.
+  additionalProperties: false
+  properties:
+    amps:
+      type: number
+      format: float
+      minimum: 1
+      maximum: 100000
+    kV:
+      <<: *voltage
+      description: The voltage in kilovolts for the current limit.
+  required:
+    - amps
+    - kV

--- a/docs/_data/components/schemas/limit.yaml
+++ b/docs/_data/components/schemas/limit.yaml
@@ -2,7 +2,7 @@ type: object
 title: Limit
 description: |
 
-  Defines the limit. In practice, most exchanges will only support one kind of
+  Defines the limit. In practice most exchanges will only support one kind of
   limit for proposals and snapshots. However, the specification supports
   defining limits on a per resource basis as well as limit types that are not
   anticipated to be used to implement Order 881. TROLIE server implementations
@@ -12,8 +12,10 @@ description: |
 
 oneOf:
   - $ref: './limit-types/active-power.yaml'
+  - $ref: './limit-types/active-power-with-power-factor.yaml'
   - $ref: './limit-types/apparent-power.yaml'
   - $ref: './limit-types/current.yaml'
+  - $ref: './limit-types/voltage.yaml#/current-with-kV'
   - $ref: './limit-types/reactive-power.yaml'
   - $ref: './limit-types/voltage.yaml#/overvoltage-threshold-pu'
   - $ref: './limit-types/voltage.yaml#/overvoltage-threshold'


### PR DESCRIPTION
closes #139 
require all fields in a limit to ensure that the slim processing is unambiguous/uncomplicated by dealing with optional fields