### PR TITLE
optional inputs for slim proposals and snapshots

### DIFF
--- a/docs/_data/components/schemas/array-max-forecast-periods.yaml
+++ b/docs/_data/components/schemas/array-max-forecast-periods.yaml
@@ -36,6 +36,12 @@ resource-forecast-proposal-slim:
   items:
     $ref: 'array-max-emergency-ratings.yaml#/slim'
 
+resource-forecast-inputs:
+  <<: *periods
+  items:
+    type: number
+    format: float
+
 missing-forecast:
   <<: *limit
   properties:

--- a/docs/_data/components/schemas/array-max-monitored-elements.yaml
+++ b/docs/_data/components/schemas/array-max-monitored-elements.yaml
@@ -22,6 +22,51 @@ forecast-limits-slim-snapshot:
       <<: *max
       items:
         $ref: 'array-max-forecast-periods.yaml#/resource-forecast-proposal-slim'
+    inputs-used: &inputs-used-slim
+      description: |
+
+        Optional list of quantities used as input to the ratings determination.
+        The particular information exchange determines which values may be expected
+        as well as the conventions used to represent those values. This property
+        is included to prescribe a way to include these inputs.
+
+      type: array
+      minItems: 1
+      maxItems: 50
+      items: &inputs-used-slim-items
+        type: object
+        properties: &inputs-used-slim-items-props
+          name:
+            type: string
+            format: free-text
+            maxLength: 50
+          values: &inputs-used-slim-items-props-values
+            <<: *max
+            description: >
+              Since this is expected to be used for wind speed or temperature,
+              we expect an array of numbers for each resource. An empty array
+              is used to indicate that the inputs are not available for a
+              particular resource. This could occur if the inputs were not provided
+              by the Ratings Provider or if a recourse rating was utilized.
+            items:
+              $ref: ./array-max-forecast-periods.yaml#/resource-forecast-inputs
+          unit:
+            type: string
+            description: |
+              Since we are not specifying which inputs shall be
+              provided, we cannot specify a definitive list of units, but
+              implementors are encouraged to use UnitSymbol from CIM when
+              appropriate: The CIM may not include appropriate units for
+              all inputs, e.g., wind speed, degrees Fahrenheit, etc.
+            format: unit
+            maxLength: 50
+        required:
+          - name
+          - values
+          - unit
+  required:
+    - snapshot-header
+    - limits
 
 forecast-limits-detailed-snapshot:
   type: object
@@ -38,6 +83,9 @@ forecast-limits-detailed-snapshot:
       description: Forecast including provenance information.
       items:
         $ref: 'array-max-forecast-periods.yaml#/forecast-limit-item-detailed'
+  required:
+    - snapshot-header
+    - limits
 
 named-power-system-resources: &psr
   <<: *max
@@ -76,6 +124,8 @@ forecast-proposal-slim:
       description: Forecasted Ratings
       items:
         $ref: 'array-max-forecast-periods.yaml#/resource-forecast-proposal-slim'
+    inputs-used:
+      <<: *inputs-used-slim
   required:
     - proposal-header
     - ratings
@@ -233,6 +283,29 @@ realtime-limits-snapshot-slim:
       description: Real-time limits
       items:
         $ref: 'array-max-emergency-ratings.yaml#/slim'
+    inputs-used:
+      <<: *inputs-used-slim
+      items:
+        <<: *inputs-used-slim-items
+        properties:
+          <<: *inputs-used-slim-items-props
+          values:
+            <<: *inputs-used-slim-items-props-values
+            description: |
+              This is aligned with the `limits` property such that each resource
+              entry is in the same position here.
+
+              A null is used to indicate that the input is not available for a
+              particular resource. This could occur if the inputs were not provided
+              by the Ratings Provider or if a recourse rating was utilized.
+            items:
+              type: number
+              format: float
+              nullable: true
+
+  required:
+    - snapshot-header
+    - limits
 
 realtime-proposal:
   type: object
@@ -255,6 +328,40 @@ realtime-proposal:
           - resource-id
         - $ref: ./limit-proposal.yaml
 
+    inputs-used: &inputs-used-slim-rt
+      <<: *inputs-used-slim
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+            format: free-text
+            maxLength: 50
+          values:
+            <<: *max
+            type: array
+            description: >
+              Since this is expected to be used for wind speed or temperature,
+              we expect an array of numbers for each resource. An empty array
+              is used to indicate that the inputs are not available for a
+              particular resource. This could occur if the inputs were not provided
+              by the Ratings Provider or if a recourse rating was utilized.
+            items:
+              $ref: ./array-max-forecast-periods.yaml#/resource-forecast-inputs
+          unit:
+            type: string
+            description: |
+              Since we are not specifying which inputs shall be
+              provided, we cannot specify a definitive list of units, but
+              implementors are encouraged to use UnitSymbol from CIM when
+              appropriate: The CIM may not include appropriate units for
+              all inputs, e.g., wind speed, degrees Fahrenheit, etc.
+            format: unit
+            maxLength: 50
+        required:
+          - name
+          - values
+          - unit
   required:
   - proposal-header
   - ratings
@@ -270,6 +377,8 @@ realtime-proposal-slim:
       description: Real-Time Ratings Proposals
       items:
         $ref: "array-max-emergency-ratings.yaml#/slim"
+    inputs-used:
+      <<: *inputs-used-slim
   required:
     - proposal-header
     - ratings

--- a/docs/_data/components/schemas/limit-proposal.yaml
+++ b/docs/_data/components/schemas/limit-proposal.yaml
@@ -35,7 +35,7 @@ allOf:
                 provided, we cannot specify a definitive list of units, but
                 implementors are encouraged to use UnitSymbol from CIM when
                 appropriate: The CIM may not include appropriate units for
-                all inputs, e.g., wind speed.
+                all inputs, e.g., wind speed, degrees Fahrenheit, etc.
               format: unit
               maxLength: 50
           required:

--- a/docs/example-narratives/examples/forecast-ratings-proposal-slim-patch.json
+++ b/docs/example-narratives/examples/forecast-ratings-proposal-slim-patch.json
@@ -41,5 +41,15 @@
       [145, 150],
       [140, 145]
     ]
+  ],
+  "inputs-used": [
+    {
+      "name": "dry bulb temperature (Fahrenheit)",
+      "unit": "degF",
+      "values": [
+        [ 50, 51, 52, 53 ],
+        [ 46.1, 46.5, 47.1, 48 ]
+      ]
+    }
   ]
 }


### PR DESCRIPTION
closes #170 

I believe we should allow the client to specify if they want `inputs-used` in the limits snapshots.

I propose we do that with a media type parameter, since we're changing the requested representation, not the requested resource as such, i.e., we're not changing which limits are in the representation or what kind of snapshot we want:

`application/vnd.trolie.realtime-limits-snapshot-slim.v1+json; inputs-used=true`
`application/vnd.trolie.forecast-limits-slim-snapshot.v1+json; inputs-used=true`

We opted not to include a slim seasonal limits snapshot, so I think we can simply document this parameterization. For the slim proposals, the `inputs-used` is optional in the spec, so the client and/or the clearinghouse provider can choose to require it or not.