### PR TITLE
use single Retry-After schema 

### DIFF
--- a/docs/_spec/openapi-split.yaml
+++ b/docs/_spec/openapi-split.yaml
@@ -436,20 +436,12 @@ components:
         maximum: 1000
     Retry-After:
       schema:
-        type: object
-        oneOf:
-          - type: integer
-            format: int32
-            minimum: 0
-            maximum: 60
-            example: 60
-            description: The seconds to delay after the response is received.
-          # TODO: the HTTP spec allows for this but we probably should not support it
-          - type: string
-            pattern: "^[A-Z][a-z]{2}, \\d{2} [A-Z][a-z]{2} \\d{4} \\d{2}:\\d{2}:\\d{2} GMT$"
-            maxLength: 30
-            example: 'Wed, 21 Oct 2022 07:28:00 GMT'
-            description: A date after which to retry.
+        type: integer
+        format: int32
+        minimum: 0
+        maximum: 60
+        example: 60
+        description: The seconds to delay after the response is received.
   securitySchemes:
     oauth2-primary-flow:
       type: oauth2


### PR DESCRIPTION
eliminates ambiguity and fixes redoc parser warnings