### PR TITLE
add "compression required" problem example for verbose GETs

### DIFF
--- a/docs/_spec/openapi-split.yaml
+++ b/docs/_spec/openapi-split.yaml
@@ -277,7 +277,7 @@ components:
       <<: *rate-limited
       description: Not Found
       content: *empty
-    '406-empty':
+    '406-problem':
       <<: *rate-limited
       description: Not Acceptable (Content negotiation failed)
       content: *problem

--- a/docs/_spec/paths/limits_forecast-snapshot.yaml
+++ b/docs/_spec/paths/limits_forecast-snapshot.yaml
@@ -108,7 +108,7 @@ current:
       '404':
         $ref: '../openapi-split.yaml#/components/responses/404-empty'
       '406':
-        $ref: '../openapi-split.yaml#/components/responses/406-empty'
+        $ref: 'limits_realtime-snapshot.yaml#/global/get/responses/406'
       '429':
         $ref: '../openapi-split.yaml#/components/responses/429-empty'
       '500': &unexpected-error-empty

--- a/docs/_spec/paths/limits_realtime-snapshot.yaml
+++ b/docs/_spec/paths/limits_realtime-snapshot.yaml
@@ -63,7 +63,18 @@ global:
       '404':
         $ref: '../openapi-split.yaml#/components/responses/404-empty'
       '406':
-        $ref: '../openapi-split.yaml#/components/responses/406-empty'
+        headers:
+          $ref: '../openapi-split.yaml#/components/responses/204/headers'
+        description: Not Acceptable (Content negotiation failed)
+        content:
+          "application/problem+json":
+            schema:
+              $ref: '../openapi-split.yaml#/components/schemas/problem'
+            examples:
+              "Compression Required":
+                summary: Only compressed responses are supported
+                value:
+                  $ref: '../../articles/examples/compression-required.json'
       '429':
         $ref: '../openapi-split.yaml#/components/responses/429-empty'
       '500': &unexpected-error-empty

--- a/docs/_spec/paths/monitoring-sets_{id}.yaml
+++ b/docs/_spec/paths/monitoring-sets_{id}.yaml
@@ -29,7 +29,7 @@ get:
     '404': 
       $ref: '../openapi-split.yaml#/components/responses/404-empty'
     '406': 
-      $ref: '../openapi-split.yaml#/components/responses/406-empty'
+      $ref: '../openapi-split.yaml#/components/responses/406-problem'
     '429': 
       $ref: '../openapi-split.yaml#/components/responses/429-empty'
     '500': &unexpected-error-empty

--- a/docs/_spec/paths/rating-proposals_forecasts.yaml
+++ b/docs/_spec/paths/rating-proposals_forecasts.yaml
@@ -45,7 +45,7 @@ get: &get
     '403': &forbidden-empty
       $ref: '../openapi-split.yaml#/components/responses/403-empty'
     '406': &not-acceptable-empty
-      $ref: '../openapi-split.yaml#/components/responses/406-empty'
+      $ref: '../openapi-split.yaml#/components/responses/406-problem'
     '429': &rate-limit-hit
       $ref: '../openapi-split.yaml#/components/responses/429-empty'
     '500': &unexpected-error-empty

--- a/docs/_spec/paths/rating-proposals_realtime.yaml
+++ b/docs/_spec/paths/rating-proposals_realtime.yaml
@@ -42,7 +42,7 @@ get:
     '403': &forbidden-empty
       $ref: '../openapi-split.yaml#/components/responses/403-empty'
     '406': &not-acceptable-empty
-      $ref: '../openapi-split.yaml#/components/responses/406-empty'
+      $ref: '../openapi-split.yaml#/components/responses/406-problem'
     '429': &rate-limit-hit
       $ref: '../openapi-split.yaml#/components/responses/429-empty'
     '500': &unexpected-error-empty

--- a/docs/_spec/paths/rating-proposals_seasonal.yaml
+++ b/docs/_spec/paths/rating-proposals_seasonal.yaml
@@ -53,7 +53,7 @@ get: &get
     '403': &forbidden-empty
       $ref: '../openapi-split.yaml#/components/responses/403-empty'
     '406': &not-acceptable-empty
-      $ref: '../openapi-split.yaml#/components/responses/406-empty'
+      $ref: '../openapi-split.yaml#/components/responses/406-problem'
     '429': &rate-limit-hit
       $ref: '../openapi-split.yaml#/components/responses/429-empty'
     '500': &unexpected-error-empty

--- a/docs/_spec/paths/seasonal-overrides.yaml
+++ b/docs/_spec/paths/seasonal-overrides.yaml
@@ -38,7 +38,7 @@ get:
     '404': &not-found-empty
       $ref: '../openapi-split.yaml#/components/responses/404-empty'
     '406': &not-acceptable-empty
-      $ref: '../openapi-split.yaml#/components/responses/406-empty'
+      $ref: '../openapi-split.yaml#/components/responses/406-problem'
     '429': &rate-limit-hit
       $ref: '../openapi-split.yaml#/components/responses/429-empty'
     '500': &unexpected-error-empty

--- a/docs/_spec/paths/seasonal-overrides_{id}.yaml
+++ b/docs/_spec/paths/seasonal-overrides_{id}.yaml
@@ -29,7 +29,7 @@ get:
     '404': &not-found-empty
       $ref: '../openapi-split.yaml#/components/responses/404-empty'
     '406': &not-acceptable-empty
-      $ref: '../openapi-split.yaml#/components/responses/406-empty'
+      $ref: '../openapi-split.yaml#/components/responses/406-problem'
     '410':
       $ref: '../openapi-split.yaml#/components/responses/410-problem'
     '429': &rate-limit-hit

--- a/docs/_spec/paths/seasonal-ratings-snapshot.yaml
+++ b/docs/_spec/paths/seasonal-ratings-snapshot.yaml
@@ -40,7 +40,7 @@ get:
     '404':
       $ref: '../openapi-split.yaml#/components/responses/404-empty'
     '406':
-      $ref: '../openapi-split.yaml#/components/responses/406-empty'
+      $ref: 'limits_realtime-snapshot.yaml#/global/get/responses/406'
     '429':
       $ref: '../openapi-split.yaml#/components/responses/429-empty'
     '500': &unexpected-error-empty

--- a/docs/_spec/paths/temporary-aar-exceptions.yaml
+++ b/docs/_spec/paths/temporary-aar-exceptions.yaml
@@ -37,7 +37,7 @@ get:
     '404': &not-found-empty
       $ref: '../openapi-split.yaml#/components/responses/404-empty'
     '406': &not-acceptable-empty
-      $ref: '../openapi-split.yaml#/components/responses/406-empty'
+      $ref: '../openapi-split.yaml#/components/responses/406-problem'
     '429': &rate-limit-hit
       $ref: '../openapi-split.yaml#/components/responses/429-empty'
     '500': &unexpected-error-empty

--- a/docs/_spec/paths/temporary-aar-exceptions_{id}.yaml
+++ b/docs/_spec/paths/temporary-aar-exceptions_{id}.yaml
@@ -29,7 +29,7 @@ get:
     '404': &not-found-empty
       $ref: '../openapi-split.yaml#/components/responses/404-empty'
     '406': &not-acceptable-empty
-      $ref: '../openapi-split.yaml#/components/responses/406-empty'
+      $ref: '../openapi-split.yaml#/components/responses/406-problem'
     '410':
       $ref: '../openapi-split.yaml#/components/responses/410-problem'
     '429': &rate-limit-hit

--- a/docs/articles/examples/compression-required.json
+++ b/docs/articles/examples/compression-required.json
@@ -1,0 +1,6 @@
+{
+  "type": "//trolie.example.com/spec/client-errors/406/compression-required",
+  "title": "Not Acceptable: Accept-Encoding Required",
+  "status": 406,
+  "detail": "This resource must be compressed with one of the following algorithms: gzip, deflate, br."
+}


### PR DESCRIPTION
just trying to squeeze this in before 1.0.0

partially addresses #81 