### PR TITLE
 change schema for authority of alternate identifiers from entity id to generic identifier

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.2)
+    activesupport (7.2.2.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -17,17 +17,18 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
     benchmark (0.4.0)
-    bigdecimal (3.1.8)
+    bigdecimal (3.1.9)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
     colorator (1.1.0)
-    commonmarker (0.23.10)
-    concurrent-ruby (1.3.4)
-    connection_pool (2.4.1)
-    csv (3.3.0)
-    dnsruby (1.72.2)
+    commonmarker (0.23.11)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.0)
+    csv (3.3.2)
+    dnsruby (1.72.3)
+      base64 (~> 0.2.0)
       simpleidn (~> 0.2.1)
     drb (2.2.1)
     em-websocket (0.5.3)
@@ -37,13 +38,13 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.10.0)
-    faraday (2.12.1)
+    faraday (2.12.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
-    ffi (1.17.0)
+    ffi (1.17.1)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (232)
@@ -214,8 +215,8 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.8.2)
-    just-the-docs (0.10.0)
+    json (2.9.1)
+    just-the-docs (0.10.1)
       jekyll (>= 3.8.5)
       jekyll-include-cache
       jekyll-seo-tag (>= 2.0)
@@ -228,16 +229,18 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.1)
+    logger (1.6.5)
     mercenary (0.3.6)
+    mini_portile2 (2.8.8)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.25.1)
-    net-http (0.5.0)
+    minitest (5.25.4)
+    net-http (0.6.0)
       uri
-    nokogiri (1.16.7-x86_64-linux)
+    nokogiri (1.18.1)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -250,9 +253,9 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.9)
+    rexml (3.4.0)
     rouge (3.30.0)
-    rubyzip (2.3.2)
+    rubyzip (2.4.1)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -262,7 +265,7 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    securerandom (0.3.2)
+    securerandom (0.4.1)
     simpleidn (0.2.3)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -272,7 +275,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
     uri (1.0.2)
-    webrick (1.9.0)
+    webrick (1.9.1)
 
 PLATFORMS
   x86_64-linux

--- a/docs/_spec/components/schemas/names.yaml
+++ b/docs/_spec/components/schemas/names.yaml
@@ -14,7 +14,7 @@ properties:
         type:
           $ref: ./name-type.yaml
         authority:
-          $ref: ./entity-id.yaml
+          $ref: ./generic-identifier.yaml
         mrid:
           $ref: ./generic-identifier.yaml
       required:

--- a/docs/_spec/openapi-split.yaml
+++ b/docs/_spec/openapi-split.yaml
@@ -52,7 +52,7 @@ info:
 
     <img src="images/interactions.excalidraw.png" alt="Primary Interactions with Ratings Provider" />
 
-  version: 1.0.0
+  version: 1.0.1
   contact:
     name: TROLIE Maintainers
     email: maintainers@trolie.energy


### PR DESCRIPTION
close #218 

@getorymckeag please take a quick look at the referenced issue to affirm the rationale of this change

As this is our first change post 1.0, I want to point out that I did increment the patch version of the spec, and I will create a new release with the appropriate tag, i.e., v1.0.1 when this is merged.