### PR TITLE
Consistently capitalized ISO-NE emergency duration names

### DIFF
--- a/docs/_spec/openapi-split.yaml
+++ b/docs/_spec/openapi-split.yaml
@@ -52,7 +52,7 @@ info:
 
     <img src="images/interactions.excalidraw.png" alt="Primary Interactions with Ratings Provider" />
 
-  version: 1.0.1
+  version: 1.0.2
   contact:
     name: TROLIE Maintainers
     email: maintainers@trolie.energy

--- a/docs/articles/tradeoffs.md
+++ b/docs/articles/tradeoffs.md
@@ -64,19 +64,19 @@ just the `ratings` object of the message.
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
             },
             {
-              "duration-name": "ste",
+              "duration-name": "STE",
               "limit": {
                 "mva": 170
               }
             },
             {
-              "duration-name": "dal",
+              "duration-name": "DAL",
               "limit": {
                 "mva": 170
               }
@@ -123,15 +123,15 @@ considerations that are addressed by the schema.
     "begins": "2025-11-01T01:00:00-05:00",
     "default-emergency-durations": [
       {
-        "name": "lte",
+        "name": "LTE",
         "duration-minutes": 240
       },
       {
-        "name": "ste",
+        "name": "STE",
         "duration-minutes": 30
       },
       {
-        "name": "dal",
+        "name": "DAL",
         "duration-minutes": 15
       }
     ],

--- a/docs/example-narratives/examples/forecast-limits-detailed-elide-names-header.json
+++ b/docs/example-narratives/examples/forecast-limits-detailed-elide-names-header.json
@@ -8,15 +8,15 @@
         },
         "default-emergency-durations": [
             {
-                "name": "lte",
+                "name": "LTE",
                 "duration-minutes": 240
             },
             {
-                "name": "ste",
+                "name": "STE",
                 "duration-minutes": 30
             },
             {
-                "name": "dal",
+                "name": "DAL",
                 "duration-minutes": 15
             }
         ]
@@ -36,15 +36,15 @@
                     },
                     "emergency-operating-limits": [
                         {
-                            "duration-name": "lte",
+                            "duration-name": "LTE",
                             "limit": { "mva": 165 }
                         },
                         {
-                            "duration-name": "ste",
+                            "duration-name": "STE",
                             "limit": { "mva": 170 }
                         },
                         {
-                            "duration-name": "dal",
+                            "duration-name": "DAL",
                             "limit": { "mva": 180 }
                         }
                     ]
@@ -71,15 +71,15 @@
                     },
                     "emergency-operating-limits": [
                         {
-                            "duration-name": "lte",
+                            "duration-name": "LTE",
                             "limit": { "mva": 160 }
                         },
                         {
-                            "duration-name": "ste",
+                            "duration-name": "STE",
                             "limit": { "mva": 165 }
                         },
                         {
-                            "duration-name": "dal",
+                            "duration-name": "DAL",
                             "limit": { "mva": 170 }
                         }
                     ]
@@ -103,15 +103,15 @@
                     },
                     "emergency-operating-limits": [
                         {
-                            "duration-name": "lte",
+                            "duration-name": "LTE",
                             "limit": { "mva": 165 }
                         },
                         {
-                            "duration-name": "ste",
+                            "duration-name": "STE",
                             "limit": { "mva": 170 }
                         },
                         {
-                            "duration-name": "dal",
+                            "duration-name": "DAL",
                             "limit": { "mva": 180 }
                         }
                     ]
@@ -124,7 +124,7 @@
                     },
                     "emergency-operating-limits": [
                         {
-                            "duration-name": "lte",
+                            "duration-name": "LTE",
                             "limit": { "mva": 165 }
                         }
                     ],

--- a/docs/example-narratives/examples/forecast-limits-detailed.json
+++ b/docs/example-narratives/examples/forecast-limits-detailed.json
@@ -8,15 +8,15 @@
         },
         "default-emergency-durations": [
             {
-                "name": "lte",
+                "name": "LTE",
                 "duration-minutes": 240
             },
             {
-                "name": "ste",
+                "name": "STE",
                 "duration-minutes": 30
             },
             {
-                "name": "dal",
+                "name": "DAL",
                 "duration-minutes": 15
             }
         ],
@@ -52,15 +52,15 @@
                     },
                     "emergency-operating-limits": [
                         {
-                            "duration-name": "lte",
+                            "duration-name": "LTE",
                             "limit": { "mva": 165 }
                         },
                         {
-                            "duration-name": "ste",
+                            "duration-name": "STE",
                             "limit": { "mva": 170 }
                         },
                         {
-                            "duration-name": "dal",
+                            "duration-name": "DAL",
                             "limit": { "mva": 180 }
                         }
                     ]
@@ -87,15 +87,15 @@
                     },
                     "emergency-operating-limits": [
                         {
-                            "duration-name": "lte",
+                            "duration-name": "LTE",
                             "limit": { "mva": 160 }
                         },
                         {
-                            "duration-name": "ste",
+                            "duration-name": "STE",
                             "limit": { "mva": 165 }
                         },
                         {
-                            "duration-name": "dal",
+                            "duration-name": "DAL",
                             "limit": { "mva": 170 }
                         }
                     ]
@@ -119,15 +119,15 @@
                     },
                     "emergency-operating-limits": [
                         {
-                            "duration-name": "lte",
+                            "duration-name": "LTE",
                             "limit": { "mva": 165 }
                         },
                         {
-                            "duration-name": "ste",
+                            "duration-name": "STE",
                             "limit": { "mva": 170 }
                         },
                         {
-                            "duration-name": "dal",
+                            "duration-name": "DAL",
                             "limit": { "mva": 180 }
                         }
                     ]
@@ -140,7 +140,7 @@
                     },
                     "emergency-operating-limits": [
                         {
-                            "duration-name": "lte",
+                            "duration-name": "LTE",
                             "limit": { "mva": 165 }
                         }
                     ],

--- a/docs/example-narratives/examples/forecast-limits-elide-psr.json
+++ b/docs/example-narratives/examples/forecast-limits-elide-psr.json
@@ -8,15 +8,15 @@
         },
         "default-emergency-durations": [
             {
-                "name": "lte",
+                "name": "LTE",
                 "duration-minutes": 240
             },
             {
-                "name": "ste",
+                "name": "STE",
                 "duration-minutes": 30
             },
             {
-                "name": "dal",
+                "name": "DAL",
                 "duration-minutes": 15
             }
         ]
@@ -34,21 +34,21 @@
                     },
                     "emergency-operating-limits": [
                         {
-                            "duration-name": "lte",
+                            "duration-name": "LTE",
                             "limit": {
                                 "mw": 170,
                                 "pf": 1.0
                             }
                         },
                         {
-                            "duration-name": "ste",
+                            "duration-name": "STE",
                             "limit": {
                                 "mw": 180,
                                 "pf": 1.0
                             }
                         },
                         {
-                            "duration-name": "dal",
+                            "duration-name": "DAL",
                             "limit": {
                                 "mw": 190,
                                 "pf": 1.0

--- a/docs/example-narratives/examples/forecast-limits-slim-active-power-dry-bulb.json
+++ b/docs/example-narratives/examples/forecast-limits-slim-active-power-dry-bulb.json
@@ -9,15 +9,15 @@
         },
         "default-emergency-durations": [
             {
-                "name": "lte",
+                "name": "LTE",
                 "duration-minutes": 240
             },
             {
-                "name": "ste",
+                "name": "STE",
                 "duration-minutes": 30
             },
             {
-                "name": "dal",
+                "name": "DAL",
                 "duration-minutes": 15
             }
         ],

--- a/docs/example-narratives/examples/forecast-limits-slim-active-power.json
+++ b/docs/example-narratives/examples/forecast-limits-slim-active-power.json
@@ -9,15 +9,15 @@
         },
         "default-emergency-durations": [
             {
-                "name": "lte",
+                "name": "LTE",
                 "duration-minutes": 240
             },
             {
-                "name": "ste",
+                "name": "STE",
                 "duration-minutes": 30
             },
             {
-                "name": "dal",
+                "name": "DAL",
                 "duration-minutes": 15
             }
         ],

--- a/docs/example-narratives/examples/forecast-limits.json
+++ b/docs/example-narratives/examples/forecast-limits.json
@@ -8,15 +8,15 @@
         },
         "default-emergency-durations": [
             {
-                "name": "lte",
+                "name": "LTE",
                 "duration-minutes": 240
             },
             {
-                "name": "ste",
+                "name": "STE",
                 "duration-minutes": 30
             },
             {
-                "name": "dal",
+                "name": "DAL",
                 "duration-minutes": 15
             }
         ],
@@ -50,21 +50,21 @@
                     },
                     "emergency-operating-limits": [
                         {
-                            "duration-name": "lte",
+                            "duration-name": "LTE",
                             "limit": {
                                 "mw": 170,
                                 "pf": 1.0
                             }
                         },
                         {
-                            "duration-name": "ste",
+                            "duration-name": "STE",
                             "limit": {
                                 "mw": 180,
                                 "pf": 1.0
                             }
                         },
                         {
-                            "duration-name": "dal",
+                            "duration-name": "DAL",
                             "limit": {
                                 "mw": 190,
                                 "pf": 1.0

--- a/docs/example-narratives/examples/forecast-ratings-proposal-patch.json
+++ b/docs/example-narratives/examples/forecast-ratings-proposal-patch.json
@@ -8,15 +8,15 @@
     "begins": "2025-11-01T01:00:00-05:00",
     "default-emergency-durations": [
       {
-        "name": "lte",
+        "name": "LTE",
         "duration-minutes": 240
       },
       {
-        "name": "ste",
+        "name": "STE",
         "duration-minutes": 30
       },
       {
-        "name": "dal",
+        "name": "DAL",
         "duration-minutes": 15
       }
     ],
@@ -41,19 +41,19 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
             },
             {
-              "duration-name": "ste",
+              "duration-name": "STE",
               "limit": {
                 "mva": 170
               }
             },
             {
-              "duration-name": "dal",
+              "duration-name": "DAL",
               "limit": {
                 "mva": 170
               }
@@ -68,19 +68,19 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
             },
             {
-              "duration-name": "ste",
+              "duration-name": "STE",
               "limit": {
                 "mva": 170
               }
             },
             {
-              "duration-name": "dal",
+              "duration-name": "DAL",
               "limit": {
                 "mva": 170
               }

--- a/docs/example-narratives/examples/realtime-limit-set-detailed-elide-psr.json
+++ b/docs/example-narratives/examples/realtime-limit-set-detailed-elide-psr.json
@@ -7,15 +7,15 @@
     },
     "default-emergency-durations": [
       {
-        "name": "lte",
+        "name": "LTE",
         "duration-minutes": 240
       },
       {
-        "name": "ste",
+        "name": "STE",
         "duration-minutes": 30
       },
       {
-        "name": "dal",
+        "name": "DAL",
         "duration-minutes": 5
       }
     ]
@@ -31,19 +31,19 @@
       },
       "emergency-operating-limits": [
         {
-          "duration-name": "lte",
+          "duration-name": "LTE",
           "limit": {
             "mva": 165
           }
         },
         {
-          "duration-name": "ste",
+          "duration-name": "STE",
           "limit": {
             "mva": 170
           }
         },
         {
-          "duration-name": "dal",
+          "duration-name": "DAL",
           "limit": {
             "mva": 175
           }
@@ -68,19 +68,19 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
             },
             {
-              "duration-name": "ste",
+              "duration-name": "STE",
               "limit": {
                 "mva": 170
               }
             },
             {
-              "duration-name": "dal",
+              "duration-name": "DAL",
               "limit": {
                 "mva": 180
               }
@@ -100,19 +100,19 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 166
               }
             },
             {
-              "duration-name": "ste",
+              "duration-name": "STE",
               "limit": {
                 "mva": 171
               }
             },
             {
-              "duration-name": "dal",
+              "duration-name": "DAL",
               "limit": {
                 "mva": 175
               }
@@ -138,19 +138,19 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
             },
             {
-              "duration-name": "ste",
+              "duration-name": "STE",
               "limit": {
                 "mva": 170
               }
             },
             {
-              "duration-name": "dal",
+              "duration-name": "DAL",
               "limit": {
                 "mva": 180
               }
@@ -165,7 +165,7 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }

--- a/docs/example-narratives/examples/realtime-limit-set-detailed.json
+++ b/docs/example-narratives/examples/realtime-limit-set-detailed.json
@@ -7,15 +7,15 @@
     },
     "default-emergency-durations": [
       {
-        "name": "lte",
+        "name": "LTE",
         "duration-minutes": 240
       },
       {
-        "name": "ste",
+        "name": "STE",
         "duration-minutes": 30
       },
       {
-        "name": "dal",
+        "name": "DAL",
         "duration-minutes": 5
       }
     ],
@@ -47,19 +47,19 @@
       },
       "emergency-operating-limits": [
         {
-          "duration-name": "lte",
+          "duration-name": "LTE",
           "limit": {
             "mva": 165
           }
         },
         {
-          "duration-name": "ste",
+          "duration-name": "STE",
           "limit": {
             "mva": 170
           }
         },
         {
-          "duration-name": "dal",
+          "duration-name": "DAL",
           "limit": {
             "mva": 175
           }
@@ -84,19 +84,19 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
             },
             {
-              "duration-name": "ste",
+              "duration-name": "STE",
               "limit": {
                 "mva": 170
               }
             },
             {
-              "duration-name": "dal",
+              "duration-name": "DAL",
               "limit": {
                 "mva": 180
               }
@@ -116,19 +116,19 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 166
               }
             },
             {
-              "duration-name": "ste",
+              "duration-name": "STE",
               "limit": {
                 "mva": 171
               }
             },
             {
-              "duration-name": "dal",
+              "duration-name": "DAL",
               "limit": {
                 "mva": 175
               }
@@ -154,19 +154,19 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
             },
             {
-              "duration-name": "ste",
+              "duration-name": "STE",
               "limit": {
                 "mva": 170
               }
             },
             {
-              "duration-name": "dal",
+              "duration-name": "DAL",
               "limit": {
                 "mva": 180
               }
@@ -181,7 +181,7 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }

--- a/docs/example-narratives/examples/realtime-limit-set-elide-psr.json
+++ b/docs/example-narratives/examples/realtime-limit-set-elide-psr.json
@@ -7,15 +7,15 @@
         },
         "default-emergency-durations": [
             {
-                "name": "lte",
+                "name": "LTE",
                 "duration-minutes": 240
             },
             {
-                "name": "ste",
+                "name": "STE",
                 "duration-minutes": 30
             },
             {
-                "name": "dal",
+                "name": "DAL",
                 "duration-minutes": 15
             }
         ]
@@ -28,19 +28,19 @@
             },
             "emergency-operating-limits": [
                 {
-                    "duration-name": "lte",
+                    "duration-name": "LTE",
                     "limit": {
                         "mva": 165
                     }
                 },
                 {
-                    "duration-name": "ste",
+                    "duration-name": "STE",
                     "limit": {
                         "mva": 170
                     }
                 },
                 {
-                    "duration-name": "dal",
+                    "duration-name": "DAL",
                     "limit": {
                         "mva": 180
                     }

--- a/docs/example-narratives/examples/realtime-limit-set.json
+++ b/docs/example-narratives/examples/realtime-limit-set.json
@@ -7,15 +7,15 @@
         },
         "default-emergency-durations": [
             {
-                "name": "lte",
+                "name": "LTE",
                 "duration-minutes": 240
             },
             {
-                "name": "ste",
+                "name": "STE",
                 "duration-minutes": 30
             },
             {
-                "name": "dal",
+                "name": "DAL",
                 "duration-minutes": 15
             }
         ],
@@ -44,19 +44,19 @@
             },
             "emergency-operating-limits": [
                 {
-                    "duration-name": "lte",
+                    "duration-name": "LTE",
                     "limit": {
                         "mva": 165
                     }
                 },
                 {
-                    "duration-name": "ste",
+                    "duration-name": "STE",
                     "limit": {
                         "mva": 170
                     }
                 },
                 {
-                    "duration-name": "dal",
+                    "duration-name": "DAL",
                     "limit": {
                         "mva": 180
                     }

--- a/docs/example-narratives/examples/realtime-proposal.json
+++ b/docs/example-narratives/examples/realtime-proposal.json
@@ -7,15 +7,15 @@
     },
     "default-emergency-durations": [
       {
-        "name": "lte",
+        "name": "LTE",
         "duration-minutes": 240
       },
       {
-        "name": "ste",
+        "name": "STE",
         "duration-minutes": 30
       },
       {
-        "name": "dal",
+        "name": "DAL",
         "duration-minutes": 15
       }
     ],
@@ -36,19 +36,19 @@
       },
       "emergency-operating-limits": [
         {
-          "duration-name": "lte",
+          "duration-name": "LTE",
           "limit": {
             "mva": 165
           }
         },
         {
-          "duration-name": "ste",
+          "duration-name": "STE",
           "limit": {
             "mva": 170
           }
         },
         {
-          "duration-name": "dal",
+          "duration-name": "DAL",
           "limit": {
             "mva": 170
           }

--- a/docs/example-narratives/examples/seasonal-ratings-proposals-conditional.json
+++ b/docs/example-narratives/examples/seasonal-ratings-proposals-conditional.json
@@ -45,7 +45,7 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "emergency",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
@@ -61,7 +61,7 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
@@ -77,7 +77,7 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
@@ -93,7 +93,7 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
@@ -114,7 +114,7 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "emergency",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
@@ -130,7 +130,7 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
@@ -146,7 +146,7 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
@@ -162,7 +162,7 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }

--- a/docs/example-narratives/examples/seasonal-ratings-proposals-patch.json
+++ b/docs/example-narratives/examples/seasonal-ratings-proposals-patch.json
@@ -36,7 +36,7 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "emergency",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
@@ -52,7 +52,7 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
@@ -68,7 +68,7 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }
@@ -84,7 +84,7 @@
           },
           "emergency-operating-limits": [
             {
-              "duration-name": "lte",
+              "duration-name": "LTE",
               "limit": {
                 "mva": 165
               }

--- a/docs/example-narratives/examples/seasonal-ratings-snapshot-detailed-elide-psr.json
+++ b/docs/example-narratives/examples/seasonal-ratings-snapshot-detailed-elide-psr.json
@@ -7,15 +7,15 @@
         },
         "default-emergency-durations": [
             {
-                "name": "lte",
+                "name": "LTE",
                 "duration-minutes": 240
             },
             {
-                "name": "ste",
+                "name": "STE",
                 "duration-minutes": 30
             },
             {
-                "name": "dal",
+                "name": "DAL",
                 "duration-minutes": 15
             }
         ]
@@ -33,19 +33,19 @@
                     },
                     "emergency-operating-limits": [
                         {
-                            "duration-name": "lte",
+                            "duration-name": "LTE",
                             "limit": {
                                 "mva": 165
                             }
                         },
                         {
-                            "duration-name": "ste",
+                            "duration-name": "STE",
                             "limit": {
                                 "mva": 170
                             }
                         },
                         {
-                            "duration-name": "dal",
+                            "duration-name": "DAL",
                             "limit": {
                                 "mva": 180
                             }
@@ -67,19 +67,19 @@
                             },
                             "emergency-operating-limits": [
                                 {
-                                    "duration-name": "lte",
+                                    "duration-name": "LTE",
                                     "limit": {
                                         "mva": 165
                                     }
                                 },
                                 {
-                                    "duration-name": "ste",
+                                    "duration-name": "STE",
                                     "limit": {
                                         "mva": 170
                                     }
                                 },
                                 {
-                                    "duration-name": "dal",
+                                    "duration-name": "DAL",
                                     "limit": {
                                         "mva": 180
                                     }

--- a/docs/example-narratives/examples/seasonal-ratings-snapshot-detailed.json
+++ b/docs/example-narratives/examples/seasonal-ratings-snapshot-detailed.json
@@ -7,15 +7,15 @@
         },
         "default-emergency-durations": [
             {
-                "name": "lte",
+                "name": "LTE",
                 "duration-minutes": 240
             },
             {
-                "name": "ste",
+                "name": "STE",
                 "duration-minutes": 30
             },
             {
-                "name": "dal",
+                "name": "DAL",
                 "duration-minutes": 15
             }
         ],
@@ -49,19 +49,19 @@
                     },
                     "emergency-operating-limits": [
                         {
-                            "duration-name": "lte",
+                            "duration-name": "LTE",
                             "limit": {
                                 "mva": 165
                             }
                         },
                         {
-                            "duration-name": "ste",
+                            "duration-name": "STE",
                             "limit": {
                                 "mva": 170
                             }
                         },
                         {
-                            "duration-name": "dal",
+                            "duration-name": "DAL",
                             "limit": {
                                 "mva": 180
                             }
@@ -83,19 +83,19 @@
                             },
                             "emergency-operating-limits": [
                                 {
-                                    "duration-name": "lte",
+                                    "duration-name": "LTE",
                                     "limit": {
                                         "mva": 165
                                     }
                                 },
                                 {
-                                    "duration-name": "ste",
+                                    "duration-name": "STE",
                                     "limit": {
                                         "mva": 170
                                     }
                                 },
                                 {
-                                    "duration-name": "dal",
+                                    "duration-name": "DAL",
                                     "limit": {
                                         "mva": 180
                                     }

--- a/docs/example-narratives/examples/seasonal-ratings-snapshot.json
+++ b/docs/example-narratives/examples/seasonal-ratings-snapshot.json
@@ -7,15 +7,15 @@
         },
         "default-emergency-durations": [
             {
-                "name": "lte",
+                "name": "LTE",
                 "duration-minutes": 240
             },
             {
-                "name": "ste",
+                "name": "STE",
                 "duration-minutes": 30
             },
             {
-                "name": "dal",
+                "name": "DAL",
                 "duration-minutes": 15
             }
         ],
@@ -49,19 +49,19 @@
                     },
                     "emergency-operating-limits": [
                         {
-                            "duration-name": "lte",
+                            "duration-name": "LTE",
                             "limit": {
                                 "mva": 165
                             }
                         },
                         {
-                            "duration-name": "ste",
+                            "duration-name": "STE",
                             "limit": {
                                 "mva": 170
                             }
                         },
                         {
-                            "duration-name": "dal",
+                            "duration-name": "DAL",
                             "limit": {
                                 "mva": 180
                             }

--- a/docs/example-narratives/reconciliation.md
+++ b/docs/example-narratives/reconciliation.md
@@ -53,5 +53,5 @@ Here's an example of the body of the response:
 
 The `proposals-considered` array contains the salient details of the ratings
 proposals that were considered.  Note that in this example the continuous,
-"lte", and "ste" limits were determined by UTILITY-A but the "dal" limit was set
+"LTE", and "STE" limits were determined by UTILITY-A but the "DAL" limit was set
 by UTILITY-B.


### PR DESCRIPTION
Closes #223.  

Since this doesn't actually change the spec at all (only documentation) I didn't _think_ this needed to come with a version update.  Let me know if you disagree.  