### PR TITLE
clarify that id parameters are opaque identifiers

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
     benchmark (0.4.1)
-    bigdecimal (3.2.1)
+    bigdecimal (3.2.2)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -43,7 +43,7 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.0)
+    faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
     ffi (1.17.2)
     forwardable-extended (2.6.0)

--- a/docs/_spec/components/parameters/id.yaml
+++ b/docs/_spec/components/parameters/id.yaml
@@ -1,7 +1,21 @@
 name: id
-description: |
-  ID of the associated object
+description: | 
+  Opaque identifier for the object. Format of this identifier may
+  very depending on the implementation.
 in: path
 required: true
 schema:
   $ref: ../schemas/generic-identifier.yaml
+examples:
+  guid:
+    value: "123e4567-e89b-12d3-a456-426614174000"
+    description: |
+      Example of a UUIDv4 identifier for an object.
+  integer:
+    value: "42"
+    description: |
+      An example of using an integer identifier.
+  datetime:
+    value: "2030-10-01T12:00:00Z"
+    description: |
+      An example of using a timestamp identifier.

--- a/docs/_spec/components/schemas/generic-identifier.yaml
+++ b/docs/_spec/components/schemas/generic-identifier.yaml
@@ -5,4 +5,4 @@ description: |
 
 maxLength: 250
 pattern: ^(.){0,250}$
-example: "//trolie.example.com/limits/forecast-snapshot/2025-07-05T01:00:00-0500"
+example: "123e4567-e89b-12d3-a456-426614174000"

--- a/docs/_spec/openapi-split.yaml
+++ b/docs/_spec/openapi-split.yaml
@@ -52,7 +52,7 @@ info:
 
     <img src="images/interactions.excalidraw.png" alt="Primary Interactions with Ratings Provider" />
 
-  version: 1.0.3
+  version: 1.0.4
   contact:
     name: TROLIE Maintainers
     email: maintainers@trolie.energy


### PR DESCRIPTION
Received some feedback that the URL as an identifier was confusing, so this makes it clear that the ids are opaque identifiers in the spec, allowing implementors to decide what to use.