### PR TITLE
pin redocly to compatible version

### DIFF
--- a/.devcontainer/post.sh
+++ b/.devcontainer/post.sh
@@ -34,7 +34,7 @@ if [[ ("${1,,}" == "bundle") || ("${1,,}" == "start") ]]; then
         kill $BUNDLE_PID
     fi
     redocly bundle $DOCS_PATH/_spec/openapi-split.yaml -o $DOCS_PATH/openapi-1.0.yaml && \
-    npx @redocly/cli lint ./docs/openapi-1.0.yaml &
+    redocly lint ./docs/openapi-1.0.yaml &
     export BUNDLE_PID=$!
 fi
 

--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@ RUN set -eux; \
 	apt update -y -qq && apt install -y -qq ruby-full build-essential \
 	&& gem install bundler;
 
-RUN npm -g install @redocly/cli
+RUN npm -g install @redocly/cli@2.11.1
 
 USER node
 

--- a/.github/workflows/crunch42-security-audit.yaml
+++ b/.github/workflows/crunch42-security-audit.yaml
@@ -18,9 +18,8 @@ jobs:
           node-version: 20
       - name: Bundle
         run: >-
-          cd docs &&
-          npx --yes @redocly/cli bundle ./_spec/openapi-split.yaml -o ./openapi-1.0.yaml &&
-          rm ./_spec/openapi-split.yaml
+          npx --yes @redocly/cli@2.11.1 bundle ./docs/_spec/openapi-split.yaml -o ./docs/openapi-1.0.yaml &&
+          rm ./docs/_spec/openapi-split.yaml
 
       - name: Audit API definition for security issues
         uses: 42Crunch/api-security-audit-action-freemium@v1

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: 20
       - name: Redocly bundle
-        run: "cd docs && npx --yes @redocly/cli bundle -d ./_spec/openapi-split.yaml -o ./openapi-1.0.yaml"
+        run: "npx --yes @redocly/cli@2.11.1 bundle -d ./docs/_spec/openapi-split.yaml -o ./docs/openapi-1.0.yaml"
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1.98.0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,11 +24,11 @@ jobs:
         with:
           node-version: 20
       - run: >-
-          cd docs && npx --yes @redocly/cli bundle -d ./_spec/openapi-split.yaml -o ./openapi-1.0.yaml &&
-          npx @redocly/cli lint ./openapi-1.0.yaml
+          npx --yes @redocly/cli@2.11.1 bundle -d ./docs/_spec/openapi-split.yaml -o ./docs/openapi-1.0.yaml &&
+          npx @redocly/cli@2.11.1 lint ./docs/openapi-1.0.yaml
       - name: Redocly API Stats
         id: api_stats
-        run: npx @redocly/cli stats ./docs/openapi-1.0.yaml > stats.txt 2>&1
+        run: npx @redocly/cli@2.11.1 stats ./docs/openapi-1.0.yaml > stats.txt 2>&1
       - name: Comment PR with API Stats
         #if: ${{ github.event.pull_request }}
         if: ${{ false }}

--- a/.github/workflows/owasp.yaml
+++ b/.github/workflows/owasp.yaml
@@ -27,7 +27,6 @@ jobs:
           node-version: 20
       - name: Lint
         run: >-
-          cd docs &&
-          npx --yes @redocly/cli bundle -d ./_spec/openapi-split.yaml -o ./openapi-1.0.yaml &&
+          npx --yes @redocly/cli@2.11.1 bundle -d ./docs/_spec/openapi-split.yaml -o ./docs/openapi-1.0.yaml &&
           cp ../.spectral.yaml . &&
-          npx --yes @stoplight/spectral-cli lint docs/openapi-1.0.yaml --ruleset .spectral.yaml --verbose
+          npx --yes @stoplight/spectral-cli lint ./docs/openapi-1.0.yaml --ruleset .spectral.yaml --verbose


### PR DESCRIPTION
redocly introduced a bug in its bundle command with version 2.12+ this causes the linter to identify hundreds of issues the issues were converted from errors to warning when the was introduced, since the  in the root was no longer implicitly used