### PR TITLE
Increase max incomplete obligations size

### DIFF
--- a/docs/_spec/components/schemas/array-max-monitored-elements.yaml
+++ b/docs/_spec/components/schemas/array-max-monitored-elements.yaml
@@ -169,7 +169,7 @@ common-proposal-status:
 
         The number of facilities for this provider whose Ratings Obligation has
         not been met in this forecast window. This number may be larger than the
-        size of `incomplete-facilities`, since the latter has a pre-defined
+        size of `incomplete-obligations`, since the latter has a pre-defined
         upper bound for performance and application security reasons.
 
         The Ratings Provider should check that this value is zero when they

--- a/docs/_spec/components/schemas/array-max-monitored-elements.yaml
+++ b/docs/_spec/components/schemas/array-max-monitored-elements.yaml
@@ -190,7 +190,7 @@ common-proposal-status:
         case for this set is debugging and troubleshooting.
 
       minItems: 0
-      maxItems: 10
+      maxItems: 100
       items:
         $ref: ./names.yaml
 

--- a/docs/_spec/components/schemas/array-max-monitored-elements.yaml
+++ b/docs/_spec/components/schemas/array-max-monitored-elements.yaml
@@ -190,7 +190,7 @@ common-proposal-status:
         case for this set is debugging and troubleshooting.
 
       minItems: 0
-      maxItems: 100
+      maxItems: *max-facilities
       items:
         $ref: ./names.yaml
 

--- a/docs/example-narratives/submitting-forecasts.md
+++ b/docs/example-narratives/submitting-forecasts.md
@@ -125,7 +125,7 @@ defines `incomplete-obligation-count`:
 
 > The number of facilities for this provider whose Ratings Obligation has
 > not been met in this forecast window. This number may be larger than the
-> size of `incomplete-facilities`, since the latter has a pre-defined
+> size of `incomplete-obligations`, since the latter has a pre-defined
 > upper bound for performance and application security reasons.
 
 > The Ratings Provider should check that this value is zero when they


### PR DESCRIPTION
Increasing the max incomplete-obligations array size from 10 to `*max-facilities`.

Also updates uses of "incomplete-facilities" to correctly use "incomplete-obligations" instead.

Closes #253 