### PR TITLE
Make provenance in seasonal snapshots consistent with forecast and real-time 

### DIFF
--- a/docs/_spec/components/schemas/array-max-monitored-elements.yaml
+++ b/docs/_spec/components/schemas/array-max-monitored-elements.yaml
@@ -508,7 +508,7 @@ seasonal-ratings-proposal-status:
 seasonal-ratings-snapshot: &seasonal-rating-snapshot
   type: object
   description: A snapshot of the seasonal ratings for a monitoring set.
-  properties: 
+  properties: &seasonal-rating-snapshot-props
     snapshot-header:
       $ref: ./headers.yaml#/seasonal-snapshot-header
     ratings:
@@ -520,17 +520,10 @@ seasonal-ratings-snapshot: &seasonal-rating-snapshot
     - snapshot-header
     - ratings
 
-seasonal-ratings-snapshot-detailed:
+seasonal-ratings-snapshot-detailed: &seasonal-rating-snapshot-detailed
   <<: *seasonal-rating-snapshot
-  description: A snapshot of the seasonal ratings for a monitoring set.
-  properties:
-    snapshot-header:
-      $ref: ./headers.yaml#/seasonal-snapshot-header
-    ratings:
-      <<: *max
-      description: Set of seasonal ratings
-      items:
-        $ref: ./array-max-seasons.yaml#/seasonal-rating-snapshot-item-detailed
+  properties: &seasonal-rating-snapshot-detailed-props
+    <<: *seasonal-rating-snapshot-props
     provenance:
       <<: *max
       description: Set of seasonal ratings provenance information
@@ -542,22 +535,11 @@ seasonal-ratings-snapshot-detailed:
     - provenance
 
 seasonal-ratings-snapshot-detailed-elide-psr:
-  <<: *seasonal-rating-snapshot
-  description: A snapshot of the seasonal ratings for a monitoring set.
+  <<: *seasonal-rating-snapshot-detailed
   properties:
+    <<: *seasonal-rating-snapshot-detailed-props
     snapshot-header:
       $ref: ./headers.yaml#/seasonal-snapshot-header-elide-psr
-    ratings:
-      description: Set of seasonal ratings
-      $ref: "#/seasonal-ratings-snapshot-detailed/properties/ratings"
-    provenance:
-      description: Set of seasonal ratings provenance information
-      items:
-        $ref: './array-max-seasons.yaml#/seasonal-rating-snapshot-provenance-item'
-  required:
-    - snapshot-header
-    - ratings
-    - provenance
 
 temporary-aar-exception-set:
   type: array

--- a/docs/_spec/components/schemas/array-max-monitored-elements.yaml
+++ b/docs/_spec/components/schemas/array-max-monitored-elements.yaml
@@ -529,6 +529,15 @@ seasonal-ratings-snapshot-detailed:
       <<: *max
       items:
         $ref: ./array-max-seasons.yaml#/seasonal-rating-snapshot-item-detailed
+    provenance:
+      <<: *max
+      description: Set of seasonal ratings provenance information
+      items:
+        $ref: './array-max-seasons.yaml#/seasonal-rating-snapshot-provenance-item'
+  required:
+    - snapshot-header
+    - ratings
+    - provenance
 
 seasonal-ratings-snapshot-detailed-elide-psr:
   <<: *seasonal-rating-snapshot
@@ -538,6 +547,14 @@ seasonal-ratings-snapshot-detailed-elide-psr:
       $ref: ./headers.yaml#/base-header
     ratings:
       $ref: "#/seasonal-ratings-snapshot-detailed/properties/ratings"
+    provenance:
+      description: Set of seasonal ratings provenance information
+      items:
+        $ref: './array-max-seasons.yaml#/seasonal-rating-snapshot-provenance-item'
+  required:
+    - snapshot-header
+    - ratings
+    - provenance
 
 temporary-aar-exception-set:
   type: array

--- a/docs/_spec/components/schemas/array-max-monitored-elements.yaml
+++ b/docs/_spec/components/schemas/array-max-monitored-elements.yaml
@@ -510,9 +510,10 @@ seasonal-ratings-snapshot: &seasonal-rating-snapshot
   description: A snapshot of the seasonal ratings for a monitoring set.
   properties: 
     snapshot-header:
-      $ref: ./headers.yaml#/common-header
+      $ref: ./headers.yaml#/seasonal-snapshot-header
     ratings:
       <<: *max
+      description: Set of seasonal ratings
       items:
         $ref: ./array-max-seasons.yaml#/seasonal-rating-snapshot-item
   required:
@@ -524,9 +525,10 @@ seasonal-ratings-snapshot-detailed:
   description: A snapshot of the seasonal ratings for a monitoring set.
   properties:
     snapshot-header:
-      $ref: ./headers.yaml#/common-header
+      $ref: ./headers.yaml#/seasonal-snapshot-header
     ratings:
       <<: *max
+      description: Set of seasonal ratings
       items:
         $ref: ./array-max-seasons.yaml#/seasonal-rating-snapshot-item-detailed
     provenance:
@@ -544,8 +546,9 @@ seasonal-ratings-snapshot-detailed-elide-psr:
   description: A snapshot of the seasonal ratings for a monitoring set.
   properties:
     snapshot-header:
-      $ref: ./headers.yaml#/base-header
+      $ref: ./headers.yaml#/seasonal-snapshot-header-elide-psr
     ratings:
+      description: Set of seasonal ratings
       $ref: "#/seasonal-ratings-snapshot-detailed/properties/ratings"
     provenance:
       description: Set of seasonal ratings provenance information

--- a/docs/_spec/components/schemas/array-max-seasons.yaml
+++ b/docs/_spec/components/schemas/array-max-seasons.yaml
@@ -78,16 +78,6 @@ seasonal-rating-snapshot-item:
       items:
         $ref: './period-limit.yaml#/seasonal-snapshot'
 
-seasonal-rating-snapshot-item-detailed:
-  type: object
-  additionalProperties: false
-  properties:
-    resource-id: *id
-    periods:
-      <<: *schedule
-      items:
-        $ref: './period-limit.yaml#/seasonal-snapshot-detailed'
-
 seasonal-rating-snapshot-provenance-item:
   type: object
   additionalProperties: false

--- a/docs/_spec/components/schemas/array-max-seasons.yaml
+++ b/docs/_spec/components/schemas/array-max-seasons.yaml
@@ -87,3 +87,14 @@ seasonal-rating-snapshot-item-detailed:
       <<: *schedule
       items:
         $ref: './period-limit.yaml#/seasonal-snapshot-detailed'
+
+seasonal-rating-snapshot-provenance-item:
+  type: object
+  additionalProperties: false
+  properties:
+    resource-id: *id
+    proposals-considered:
+      $ref: './period-limit.yaml#/seasonal-proposals-considered'
+  required:
+    - resource-id
+    - proposals-considered

--- a/docs/_spec/components/schemas/headers.yaml
+++ b/docs/_spec/components/schemas/headers.yaml
@@ -196,3 +196,13 @@ seasonal-proposal-header-slim:
     - default-emergency-durations
     - power-system-resources
     - default-seasonal-schedule
+
+seasonal-snapshot-header:
+  <<: *common-header
+  description: Details about the snapshot provided by the Clearinghouse provider.
+
+seasonal-snapshot-header-elide-psr:
+  <<: *base-header
+  description: |
+    Details about the snapshot provided by the Clearinghouse provider. The
+    `power-system-resources` property is omitted from this header.

--- a/docs/_spec/components/schemas/period-limit.yaml
+++ b/docs/_spec/components/schemas/period-limit.yaml
@@ -212,6 +212,10 @@ seasonal-proposal-considered:
   required:
     - source
     - resource-id
+    - period-start
+    - period-end
+    - continuous-operating-limit
+    - emergency-operating-limits
 
 seasonal-snapshot-detailed:
   <<: *seasonal-snapshot
@@ -219,22 +223,19 @@ seasonal-snapshot-detailed:
   title: Seasonal Rating Proposal
   properties:
     <<: *seasonal-snapshot-props
-    proposals-considered:
-      description: |
-
-        The seasonal ratings proposals considered when determining the
-        seasonal ratings of a power system resource, e.g., a line or
-        transformer.
-
-      type: array
-      minItems: 1
-      maxItems: 10
-      items:
-        $ref: '#/seasonal-proposal-considered'
   required:
-    - proposals-considered
     - period-start
     - period-end
     - continuous-operating-limit
     - emergency-operating-limits
   additionalProperties: false
+
+seasonal-proposals-considered:
+  description: |
+    The proposals considered when determining the
+    seasonal ratings of a power system resource, e.g., a line or
+    transformer.
+  type: array
+  maxItems: 48 # 12 periods * 4 proposals per period
+  items:
+    $ref: '#/seasonal-proposal-considered'

--- a/docs/_spec/components/schemas/period-limit.yaml
+++ b/docs/_spec/components/schemas/period-limit.yaml
@@ -189,7 +189,7 @@ seasonal-proposal-slim:
       `[normal_MVA, emergency_MVA]`, we would have `[normal_MW, normal_pf,
       emergency_MW, emergency_pf]`, e.g., `[300, 1.0, 350, 1.0]`.
 
-seasonal-snapshot: &seasonal-snapshot
+seasonal-snapshot:
   <<: *forecast-snapshot
   description: Proposes the continuous and emergency ratings for the specified Season.
   title: Seasonal Rating Proposal
@@ -216,19 +216,6 @@ seasonal-proposal-considered:
     - period-end
     - continuous-operating-limit
     - emergency-operating-limits
-
-seasonal-snapshot-detailed:
-  <<: *seasonal-snapshot
-  description: Proposes the continuous and emergency ratings for the specified Season.
-  title: Seasonal Rating Proposal
-  properties:
-    <<: *seasonal-snapshot-props
-  required:
-    - period-start
-    - period-end
-    - continuous-operating-limit
-    - emergency-operating-limits
-  additionalProperties: false
 
 seasonal-proposals-considered:
   description: |

--- a/docs/example-narratives/examples/seasonal-ratings-snapshot-detailed-elide-psr.json
+++ b/docs/example-narratives/examples/seasonal-ratings-snapshot-detailed-elide-psr.json
@@ -50,41 +50,46 @@
                                 "mva": 180
                             }
                         }
-                    ],
-                    "proposals-considered": [
+                    ]
+                }
+            ]
+        }
+    ],
+    "provenance":[
+        {
+            "resource-id": "8badf00d",
+            "proposals-considered": [
+                {
+                    "resource-id": "8badf00d-UTILITY-A-SEG-id",
+                    "period-start": "2024-04-01T01:00:00Z",
+                    "period-end": "2024-07-01T01:00:00Z",
+                    "source": {
+                        "provider": "UTILITY-A",
+                        "last-updated": "2023-07-12T16:00:00-07:00",
+                        "origin-id": "8badf00d-UTILITY-A-correlation-id"
+                    },
+                    "season-name": "spring",
+                    "continuous-operating-limit": {
+                        "mva": 160
+                    },
+                    "emergency-operating-limits": [
                         {
-                            "resource-id": "8badf00d",
-                            "period-start": "2024-04-01T01:00:00Z",
-                            "period-end": "2024-07-01T01:00:00Z",
-                            "source": {
-                                "provider": "X-AMPL",
-                                "last-updated": "2023-07-12T16:00:00-07:00",
-                                "origin-id": "//trolie.example.com/snapshots/2024-08-05T11%3a00%3a00-07%3a00"
-                            },
-                            "season-name": "spring",
-                            "continuous-operating-limit": {
-                                "mva": 160
-                            },
-                            "emergency-operating-limits": [
-                                {
-                                    "duration-name": "LTE",
-                                    "limit": {
-                                        "mva": 165
-                                    }
-                                },
-                                {
-                                    "duration-name": "STE",
-                                    "limit": {
-                                        "mva": 170
-                                    }
-                                },
-                                {
-                                    "duration-name": "DAL",
-                                    "limit": {
-                                        "mva": 180
-                                    }
-                                }
-                            ]
+                            "duration-name": "LTE",
+                            "limit": {
+                                "mva": 165
+                            }
+                        },
+                        {
+                            "duration-name": "STE",
+                            "limit": {
+                                "mva": 170
+                            }
+                        },
+                        {
+                            "duration-name": "DAL",
+                            "limit": {
+                                "mva": 180
+                            }
                         }
                     ]
                 }

--- a/docs/example-narratives/examples/seasonal-ratings-snapshot-detailed.json
+++ b/docs/example-narratives/examples/seasonal-ratings-snapshot-detailed.json
@@ -66,41 +66,46 @@
                                 "mva": 180
                             }
                         }
-                    ],
-                    "proposals-considered": [
+                    ]
+                }
+            ]
+        }
+    ],
+    "provenance":[
+        {
+            "resource-id": "8badf00d",
+            "proposals-considered": [
+                {
+                    "resource-id": "8badf00d-UTILITY-A-SEG-id",
+                    "period-start": "2024-04-01T01:00:00Z",
+                    "period-end": "2024-07-01T01:00:00Z",
+                    "source": {
+                        "provider": "UTILITY-A",
+                        "last-updated": "2023-07-12T16:00:00-07:00",
+                        "origin-id": "8badf00d-UTILITY-A-correlation-id"
+                    },
+                    "season-name": "spring",
+                    "continuous-operating-limit": {
+                        "mva": 160
+                    },
+                    "emergency-operating-limits": [
                         {
-                            "resource-id": "8badf00d",
-                            "period-start": "2024-04-01T01:00:00Z",
-                            "period-end": "2024-07-01T01:00:00Z",
-                            "source": {
-                                "provider": "X-AMPL",
-                                "last-updated": "2023-07-12T16:00:00-07:00",
-                                "origin-id": "//trolie.example.com/snapshots/2024-08-05T11%3a00%3a00-07%3a00"
-                            },
-                            "season-name": "spring",
-                            "continuous-operating-limit": {
-                                "mva": 160
-                            },
-                            "emergency-operating-limits": [
-                                {
-                                    "duration-name": "LTE",
-                                    "limit": {
-                                        "mva": 165
-                                    }
-                                },
-                                {
-                                    "duration-name": "STE",
-                                    "limit": {
-                                        "mva": 170
-                                    }
-                                },
-                                {
-                                    "duration-name": "DAL",
-                                    "limit": {
-                                        "mva": 180
-                                    }
-                                }
-                            ]
+                            "duration-name": "LTE",
+                            "limit": {
+                                "mva": 165
+                            }
+                        },
+                        {
+                            "duration-name": "STE",
+                            "limit": {
+                                "mva": 170
+                            }
+                        },
+                        {
+                            "duration-name": "DAL",
+                            "limit": {
+                                "mva": 180
+                            }
                         }
                     ]
                 }


### PR DESCRIPTION
* Updated seasonal snapshots schema to include a `provenance` array to match forecast and real-time. Each provenance item will contain a resource id and a `proposals-considered` array. 
* Updated the max size of the `proposals-considered` array from 12 to 48 to support the possibility of 12 periods with 4 proposals each. This follows the assumption of 4 proposals per period made in forecast proposals considered.
* In addition to `source` and `resource-id` being required for each `proposal-considered` item, I also made `period-start`, `period-end`, `cotinuous-operating-limit`, and `emergency-operating-limits` required to match existing schemas.
* Updated the seasonal snapshot examples to match the new schema.
* Also adds custom seasonal snapshot header types rather than directly using `common-header` and `base-header` to match forecast and real time.

The spec looks like the following after the changes:

<img width="1311" height="497" alt="{1915AD3F-3F4F-48F7-B60F-49188791AD97}" src="https://github.com/user-attachments/assets/f08b15b1-54b2-4fad-bb8b-5bc830b22846" />

Closes #252 
