### PR TITLE
BUGFIX: Fixed bad description, rate limit headers

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.3)
+    activesupport (7.2.3.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -10,24 +10,24 @@ GEM
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
-      minitest (>= 5.1)
+      minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
     colorator (1.1.0)
     commonmarker (0.23.12)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.8)
     connection_pool (2.5.5)
     csv (3.3.5)
-    dnsruby (1.73.1)
+    dnsruby (1.74.0)
       base64 (>= 0.2)
       logger (~> 1.6)
       simpleidn (~> 0.2.1)
@@ -39,14 +39,14 @@ GEM
       ffi (>= 1.15.0)
       logger
     eventmachine (1.2.7)
-    execjs (2.10.0)
-    faraday (2.14.1)
+    execjs (2.10.1)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
-    ffi (1.17.3)
+    ffi (1.17.4)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (232)
@@ -105,7 +105,7 @@ GEM
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.8.1)
-    i18n (1.14.8)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     jekyll (3.10.0)
       addressable (~> 2.4)
@@ -217,7 +217,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.18.1)
+    json (2.21.1)
     just-the-docs (0.12.0)
       jekyll (>= 3.8.5)
       jekyll-include-cache
@@ -252,7 +252,7 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (5.1.1)
     racc (1.8.1)
-    rake (13.3.1)
+    rake (13.4.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
@@ -272,8 +272,8 @@ GEM
     simpleidn (0.2.3)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    typhoeus (1.4.1)
-      ethon (>= 0.9.0)
+    typhoeus (1.6.0)
+      ethon (>= 0.18.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)

--- a/docs/_spec/openapi-split.yaml
+++ b/docs/_spec/openapi-split.yaml
@@ -237,12 +237,12 @@ components:
     '304': &rate-limited
       description: Not Modified.
       headers: &rate-limited-headers
-        X-Rate-Limit-Limit:
-          $ref: '#/components/headers/X-Rate-Limit-Limit'
-        X-Rate-Limit-Remaining:
-          $ref: '#/components/headers/X-Rate-Limit-Remaining'
-        X-Rate-Limit-Reset:
-          $ref: '#/components/headers/X-Rate-Limit-Reset'
+        X-RateLimit-Limit:
+          $ref: '#/components/headers/X-RateLimit-Limit'
+        X-RateLimit-Remaining:
+          $ref: '#/components/headers/X-RateLimit-Remaining'
+        X-RateLimit-Reset:
+          $ref: '#/components/headers/X-RateLimit-Reset'
     '204':
       description: Operation successful. No Content.
       headers: &accepted-headers
@@ -407,21 +407,21 @@ components:
         format: uri-reference
         maxLength: 1000
 
-    X-Rate-Limit-Limit:
+    X-RateLimit-Limit:
       description: The number of allowed requests in the current period
       schema:
         type: integer
         format: int32
         minimum: 0
         maximum: 1000
-    X-Rate-Limit-Remaining:
+    X-RateLimit-Remaining:
       description: The number of remaining requests in the current period
       schema:
         type: integer
         format: int32
         minimum: 0
         maximum: 1000
-    X-Rate-Limit-Reset:
+    X-RateLimit-Reset:
       description: The number of seconds left in the current period
       schema:
         type: integer

--- a/docs/_spec/paths/seasonal-ratings-snapshot.yaml
+++ b/docs/_spec/paths/seasonal-ratings-snapshot.yaml
@@ -1,6 +1,6 @@
 get:
   operationId: getSeasonalRatingsSnapshot
-  description: Retrieve the nominal and seasonal ratings.
+  description: Retrieve seasonal ratings.
   summary: Get Seasonal Ratings
   tags:
     - Seasonal

--- a/docs/articles/conditional-GET.md
+++ b/docs/articles/conditional-GET.md
@@ -39,9 +39,9 @@ Content-Type: application/vnd.trolie.forecast-limits-snapshot.v1+json
 Server: trolie.example.com
 Date: Wed, 29 Feb 2024 12:00:00 GMT
 ETag: "d41d8cd98f00b204e9800998ecf8427e"
-X-Rate-Limit-Limit: 100
-X-Rate-Limit-Remaining: 98
-X-Rate-Limit-Reset: 3600
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 98
+X-RateLimit-Reset: 3600
 
 {... response body in Brotli compressed format ...}
 ```
@@ -73,15 +73,15 @@ HTTP/1.1 304 Not Modified
 ETag: "d41d8cd98f00b204e9800998ecf8427e"
 Server: trolie.example.com
 Date: Wed, 29 Feb 2024 12:03:20 GMT
-X-Rate-Limit-Limit: 100
-X-Rate-Limit-Remaining: 97
-X-Rate-Limit-Reset: 3400
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 97
+X-RateLimit-Reset: 3400
 ```
 
 {: .nb }
 
 > <i class="fa-solid fa-triangle-exclamation"></i> **Note**:
-> The `X-Rate-Limit-Remaining` is decremented here, since
+> The `X-RateLimit-Remaining` is decremented here, since
 > rate limiting is applied in all circumstances, including
 > 3XX and 4XX responses.
 
@@ -93,9 +93,9 @@ Content-Type: application/vnd.trolie.forecast-limits-snapshot.v1+json
 Server: trolie.example.com
 Date: Wed, 29 Feb 2024 12:03:20 GMT
 ETag: "123e4567e89b12d3a456426614174000"
-X-Rate-Limit-Limit: 100
-X-Rate-Limit-Remaining: 97
-X-Rate-Limit-Reset: 3400
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 97
+X-RateLimit-Reset: 3400
 Content-Encoding: br
 
 {... response body in Brotli compressed format ...}

--- a/docs/articles/how-units-are-handled.md
+++ b/docs/articles/how-units-are-handled.md
@@ -51,9 +51,9 @@ HTTP/1.1 422 Unprocessable Entity
 Content-Type: application/problem+json
 Server: trolie.example.com
 Date: Wed, 6 May 2025 12:00:00 GMT
-X-Rate-Limit-Limit: 100
-X-Rate-Limit-Remaining: 98
-X-Rate-Limit-Reset: 3600
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 98
+X-RateLimit-Reset: 3600
 
 {% include_relative examples/proposal-invalid-units.json %}
 ```
@@ -105,9 +105,9 @@ HTTP/1.1 422 Unprocessable Entity
 Content-Type: application/problem+json
 Server: trolie.example.com
 Date: Wed, 1 Nov 2025 12:00:00 GMT
-X-Rate-Limit-Limit: 100
-X-Rate-Limit-Remaining: 98
-X-Rate-Limit-Reset: 3600
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 98
+X-RateLimit-Reset: 3600
 
 {
   "type": "//trolie.example.com/spec/client-errors/422/invalid-units",

--- a/docs/example-narratives/submitting-forecasts.md
+++ b/docs/example-narratives/submitting-forecasts.md
@@ -91,9 +91,9 @@ Content-Type: application/vnd.trolie.rating-forecast-proposal-status.v1+json
 Server: trolie.example.com
 Date: Wed, 29 Feb 2024 12:03:20 GMT
 ETag: "123e4567e89b12d3a456426614174000"
-X-Rate-Limit-Limit: 100
-X-Rate-Limit-Remaining: 97
-X-Rate-Limit-Reset: 3400
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 97
+X-RateLimit-Reset: 3400
 
 
 {% include_relative examples/forecast-ratings-proposal-status.json %}


### PR DESCRIPTION
Removed reference to nominal ratings in seasonal rating snapshot.  Closes #264.  
Also renamed rate limiting headers to match tooling standards.  Closes #265 